### PR TITLE
fix(redis): restore comma-separated cluster seed-node parsing

### DIFF
--- a/openframe/docs/redis-key-prefix.md
+++ b/openframe/docs/redis-key-prefix.md
@@ -118,6 +118,23 @@ dedicated vuln-processing cron
 ([cron-vulnprocessing.yaml](../../charts/fleet/templates/cron-vulnprocessing.yaml))
 receive the same prefix, so background jobs share the tenant's keyspace.
 
+## Cluster seed nodes — `OPENFRAME(redis-seed-nodes)`
+
+Upstream initializes the `redisc.Cluster` with a single startup node
+(`StartupNodes: []string{conf.Server}`) and relies on `CLUSTER SLOTS` discovery.
+The fork's multi-tenant deploys instead pass an explicit, comma-separated node
+list in `FLEET_REDIS_ADDRESS` (e.g. `redis-0:6379,redis-1:6379,redis-2:6379`).
+`splitSeedNodes()` in [`redis.go`](../../server/datastore/redis/redis.go) parses
+that list (trimming whitespace and a `redis://` scheme per entry) into
+`StartupNodes`.
+
+**Without it, startup fails** with `redisc: all nodes failed … dial tcp: address
+<list>: too many colons in address`, because the whole comma-joined string is
+treated as one host:port. This edit was dropped once during an upstream sync
+(it had no marker then); it is now marked and covered by `TestSplitSeedNodes` in
+[`seednodes_test.go`](../../server/datastore/redis/seednodes_test.go) and the
+`redis-seed-nodes` slug in `openframe/scripts/verify.sh`.
+
 ## Files changed
 
 | File | Purpose |

--- a/openframe/scripts/verify.sh
+++ b/openframe/scripts/verify.sh
@@ -46,7 +46,7 @@ rm -f vet.err
 # 3. Marker presence: if a merge silently dropped fork code, its OPENFRAME markers
 #    vanish too. A slug dropping to zero is a red flag worth a human look.
 step "OPENFRAME marker presence (dropped-fork-code detector)"
-for slug in host-assignments redis-key-prefix query-results-ttl osquery-host-id agent-openframe-mode; do
+for slug in host-assignments redis-key-prefix redis-seed-nodes query-results-ttl osquery-host-id agent-openframe-mode; do
   n=$(grep -rIl "OPENFRAME($slug" --include='*.go' --include='*.yaml' --include='*.tpl' . 2>/dev/null | wc -l | tr -d ' ')
   if [ "$n" -gt 0 ]; then ok "$slug — present in $n file(s)"; else bad "$slug — NO markers found (fork code may have been dropped in the merge)"; fi
 done
@@ -65,6 +65,7 @@ TOKENS=re.compile('|'.join([
  r'HostsIncludeAny',r'\bHostIdent\b',r'loadHostsFor(Policies|Queries)',
  r'(Add|Remove|Replace|List)(Policy|Query)Hosts',r'normalizeKeyPrefix',r'newPrefixedConn',
  r'\bprefixedConn\b',r'unwrapConn',r'keyPrefixOf',r'FLEET_REDIS_KEY_PREFIX',r'redis\.key_prefix',
+ r'splitSeedNodes',
  r'QueryResultsTTL',r'QueryResultsCleanupInterval',r'CleanupExpiredQueryResults',
  r'CronQueryResultsTTLCleanup',r'newQueryResultsTTLCleanupSchedule',r'query_results_ttl',
  r'query_results_cleanup_interval',r'json:"osquery_host_id"']))
@@ -92,7 +93,7 @@ else bad "unmarked fork-token line(s) above — wrap each in an OPENFRAME marker
 # 4. Pure-logic unit tests (no Docker). The key-prefix test is the highest-value
 #    guard: a regression here is a cross-tenant data leak.
 step "key-prefix unit tests (no Docker)"
-if go test ./server/datastore/redis/ -run 'PrefixArgs|NormalizeKeyPrefix|PrefixedConn|UnwrapConn|ByteKeys' >redis.test 2>&1; then
+if go test ./server/datastore/redis/ -run 'PrefixArgs|NormalizeKeyPrefix|PrefixedConn|UnwrapConn|ByteKeys|SplitSeedNodes' >redis.test 2>&1; then
   ok "redis key-prefix tests"
 else
   bad "redis key-prefix tests"; sed 's/^/    /' redis.test | tail -30

--- a/server/datastore/redis/redis.go
+++ b/server/datastore/redis/redis.go
@@ -432,7 +432,9 @@ func newCluster(conf PoolConfig) (*redisc.Cluster, error) {
 	}
 
 	return &redisc.Cluster{
-		StartupNodes: splitSeedNodes(conf.Server), // OPENFRAME(redis-seed-nodes): split comma-separated seed nodes — openframe/docs/redis-key-prefix.md
+		// >>> OPENFRAME(redis-seed-nodes): split comma-separated FLEET_REDIS_ADDRESS into cluster seed nodes — openframe/docs/redis-key-prefix.md
+		StartupNodes: splitSeedNodes(conf.Server),
+		// <<< OPENFRAME(redis-seed-nodes)
 		PoolWaitTime: conf.ConnWaitTimeout,
 		DialOptions:  opts,
 		CreatePool: func(server string, opts ...redis.DialOption) (*redis.Pool, error) {

--- a/server/datastore/redis/redis.go
+++ b/server/datastore/redis/redis.go
@@ -168,6 +168,31 @@ func normalizeKeyPrefix(p string) (string, error) {
 
 // <<< OPENFRAME(redis-key-prefix)
 
+// >>> OPENFRAME(redis-seed-nodes): parse comma-separated FLEET_REDIS_ADDRESS into multiple cluster seed nodes — openframe/docs/redis-key-prefix.md
+// splitSeedNodes parses FLEET_REDIS_ADDRESS into seed host:port entries.
+// Accepts a single addr, a redis:// URL, or a comma-separated mix; trims the
+// scheme and whitespace per entry. Without this, a comma-separated address is
+// handed to the cluster as a single node and the dialer fails with "too many
+// colons in address". Upstream uses one startup node and relies on CLUSTER
+// SLOTS discovery; the fork's multi-tenant deploys pass an explicit node list.
+func splitSeedNodes(server string) []string {
+	if server == "" {
+		return nil
+	}
+	parts := strings.Split(server, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		p = strings.TrimPrefix(p, "redis://")
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// <<< OPENFRAME(redis-seed-nodes)
+
 // ReadOnlyConn turns conn into a connection that will try to connect to a
 // replica instead of a primary. Note that this is not guaranteed that it will
 // do so (there may not be any replica, or due to redirections it may end up on
@@ -407,7 +432,7 @@ func newCluster(conf PoolConfig) (*redisc.Cluster, error) {
 	}
 
 	return &redisc.Cluster{
-		StartupNodes: []string{conf.Server},
+		StartupNodes: splitSeedNodes(conf.Server), // OPENFRAME(redis-seed-nodes): split comma-separated seed nodes — openframe/docs/redis-key-prefix.md
 		PoolWaitTime: conf.ConnWaitTimeout,
 		DialOptions:  opts,
 		CreatePool: func(server string, opts ...redis.DialOption) (*redis.Pool, error) {

--- a/server/datastore/redis/seednodes_test.go
+++ b/server/datastore/redis/seednodes_test.go
@@ -1,0 +1,36 @@
+// OPENFRAME(redis-seed-nodes): unit test for comma-separated cluster seed-node
+// parsing — openframe/docs/redis-key-prefix.md
+//
+// This guards a regression that already bit once: the sync reset redis.go toward
+// upstream and dropped splitSeedNodes, so a comma-separated FLEET_REDIS_ADDRESS
+// was passed to the cluster as one node and startup failed with "too many colons
+// in address". Pure logic, no live Redis.
+package redis
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitSeedNodes(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"single", "redis-0:6379", []string{"redis-0:6379"}},
+		{"comma list", "a:6379,b:6379,c:6379", []string{"a:6379", "b:6379", "c:6379"}},
+		{"whitespace trimmed", " a:6379 , b:6379 ", []string{"a:6379", "b:6379"}},
+		{"redis:// scheme stripped", "redis://a:6379,redis://b:6379", []string{"a:6379", "b:6379"}},
+		{"empty entries dropped", "a:6379,,b:6379,", []string{"a:6379", "b:6379"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := splitSeedNodes(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("splitSeedNodes(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Restore comma-separated cluster seed-node parsing

The upstream sync reset server/datastore/redis/redis.go toward upstream's single-node form (StartupNodes: []string{conf.Server}) and dropped the fork's splitSeedNodes() helper, which had no OPENFRAME marker. A comma-separated FLEET_REDIS_ADDRESS was then handed to the cluster as one node, so startup failed with "redisc: all nodes failed ... dial tcp: address <list>: too many colons in address".

Restore splitSeedNodes() and wire it into StartupNodes, now wrapped in an OPENFRAME(redis-seed-nodes) marker. Add TestSplitSeedNodes and register the slug/token/test in openframe/scripts/verify.sh so a future sync cannot silently drop it again. Documented in openframe/docs/redis-key-prefix.md.


## Task
[Link](https://app.clickup.com/t/example)
<!-- Links to any related tickets, issues, or requirements -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redis cluster initialization now supports multiple comma-separated seed node addresses, enabling flexible multi-node cluster configuration.

* **Tests**
  * Added test coverage for seed node address parsing, including whitespace handling and URI scheme processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->