### PR TITLE
fix(goose): return version 0 instead of panicking on the migration↔serve race

### DIFF
--- a/openframe/docs/migrations.md
+++ b/openframe/docs/migrations.md
@@ -242,3 +242,31 @@ When rebasing onto a newer upstream release:
 ## Known issue: `prepare db` early return (fixed)
 
 Previously, `cmd/fleet/prepare.go` had an early `return` when `MigrationStatus()` reported `AllMigrationsCompleted`. Since `MigrationStatus()` only checks `tables` and `data` migrations, this caused `MigrateOpenframe()` to be skipped on databases where upstream migrations were already applied. The fix removes the early return so that openframe migrations always execute.
+
+## Migration ↔ serve startup race — `OPENFRAME(migration-race)`
+
+On a **fresh** database the `fleet-migration` job (`fleet prepare db`) and the
+`fleet` server (`fleet serve`) can start **concurrently** — the fork removed the
+migration job's pre-install/pre-upgrade Helm hook (`Remove Chart Pre Hooks (#37)`,
+`ba4887475d`) that upstream still uses to run migrations to completion before the
+server. Both processes call `MigrationStatus()` → goose `GetDBVersion()` at startup.
+
+goose's `createVersionTable` runs `CREATE TABLE` then `INSERT version 0` in one
+transaction, but **MySQL auto-commits DDL**, so the `CREATE TABLE` becomes visible
+to other connections before the version-0 row is inserted. A process that queries
+the version table in that window sees it **existing but empty**, and upstream goose
+hits `panic("unreachable")` — crash-looping both the server and the migration job
+(observed on a freshly-provisioned stage tenant).
+
+**Fork fix** (`server/goose/migrate.go`, marked `OPENFRAME(migration-race)`): when
+`GetDBVersion` finds the version table present but with no applied row, it returns
+version `0` instead of panicking. The process then treats the DB as unmigrated and
+lets the **idempotent** migrations proceed/retry — so it self-heals (rather than
+crash-loops) from both this race and a version table whose rows were lost. Pinned by
+`TestGetDBVersion_EmptyVersionTableReturnsZeroNotPanic`
+(`server/goose/migrate_openframe_test.go`, go-sqlmock, no live MySQL).
+
+> This is a defensive guard. The **root cause** is the missing ordering; the durable
+> fix is to restore the migration job's `pre-install,pre-upgrade` Helm hook (or add a
+> wait-for-migration init container to the server Deployment) so migrations complete
+> before the server starts — see [helm-chart.md](helm-chart.md).

--- a/openframe/scripts/verify.sh
+++ b/openframe/scripts/verify.sh
@@ -46,7 +46,7 @@ rm -f vet.err
 # 3. Marker presence: if a merge silently dropped fork code, its OPENFRAME markers
 #    vanish too. A slug dropping to zero is a red flag worth a human look.
 step "OPENFRAME marker presence (dropped-fork-code detector)"
-for slug in host-assignments redis-key-prefix redis-seed-nodes query-results-ttl osquery-host-id agent-openframe-mode; do
+for slug in host-assignments redis-key-prefix redis-seed-nodes query-results-ttl osquery-host-id agent-openframe-mode migration-race; do
   n=$(grep -rIl "OPENFRAME($slug" --include='*.go' --include='*.yaml' --include='*.tpl' . 2>/dev/null | wc -l | tr -d ' ')
   if [ "$n" -gt 0 ]; then ok "$slug — present in $n file(s)"; else bad "$slug — NO markers found (fork code may have been dropped in the merge)"; fi
 done

--- a/server/goose/migrate.go
+++ b/server/goose/migrate.go
@@ -207,7 +207,15 @@ func (c *Client) GetDBVersion(db *sql.DB) (int64, error) {
 		return 0, err
 	}
 
-	panic("unreachable")
+	// >>> OPENFRAME(migration-race): a concurrently-created-but-unseeded version
+	// table must not crash the process. On MySQL the CREATE TABLE in
+	// createVersionTable auto-commits before the version-0 INSERT, so a reader
+	// racing the migration job on a fresh DB can observe the table existing but
+	// empty (this also covers a version table whose rows were lost). Treat "no
+	// applied row" as version 0 (nothing applied) and let the idempotent
+	// migrations proceed/retry instead of panicking. — openframe/docs/migrations.md
+	return 0, nil
+	// <<< OPENFRAME(migration-race)
 }
 
 // Create the goose_db_version table

--- a/server/goose/migrate_openframe_test.go
+++ b/server/goose/migrate_openframe_test.go
@@ -1,0 +1,44 @@
+// OPENFRAME(migration-race): regression test for GetDBVersion against an
+// empty/unseeded version table — openframe/docs/migrations.md
+//
+// On a fresh DB the migration job (`fleet prepare db`) and the server
+// (`fleet serve`) can start concurrently (the fork removed the migration Helm
+// hook). MySQL auto-commits goose's CREATE TABLE before its version-0 INSERT,
+// so one process can observe the version table existing but empty. Upstream
+// goose `panic("unreachable")`s in that case; the fork returns version 0 so the
+// idempotent migrations proceed/retry instead of crash-looping. This test pins
+// that behavior. Pure logic — uses go-sqlmock, no live MySQL.
+package goose
+
+import (
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestGetDBVersion_EmptyVersionTableReturnsZeroNotPanic(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	// Version table EXISTS (query succeeds) but returns ZERO rows — the race
+	// window where CREATE TABLE has committed but the version-0 INSERT has not.
+	mock.ExpectQuery("SELECT version_id, is_applied from migration_status_tables").
+		WillReturnRows(sqlmock.NewRows([]string{"version_id", "is_applied"}))
+
+	c := New("migration_status_tables", MySqlDialect{})
+
+	// Must NOT panic, and must report version 0 (nothing applied yet).
+	got, err := c.GetDBVersion(db)
+	if err != nil {
+		t.Fatalf("GetDBVersion returned error: %v", err)
+	}
+	if got != 0 {
+		t.Fatalf("GetDBVersion = %d, want 0 for an empty version table", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Description

On a freshly-provisioned tenant the `fleet-migration` job (`fleet prepare db`) and the `fleet` server (`fleet serve`) start **concurrently** — the fork removed the migration job's `pre-install,pre-upgrade` Helm hook (`Remove Chart Pre Hooks (#37)`), which upstream still uses to run migrations to completion before the server. Both call `MigrationStatus()` → goose `GetDBVersion()` at startup.

Because **MySQL auto-commits DDL**, goose's `createVersionTable` makes the `CREATE TABLE` visible to other connections *before* its `INSERT version 0` commits. A process that reads the version table in that window sees it **existing but empty**, and upstream goose hits `panic("unreachable")` — crash-looping both the server and the migration job (observed on a fresh stage tenant; `fleet-...` in `CrashLoopBackOff` + `fleet-migration` in `Error`, both panicking at `server/goose/migrate.go:210`).

`GetDBVersion` now treats "version table present but no applied row" as version **0** instead of panicking, so the idempotent migrations proceed/retry and the service **self-heals** — from both this race and a version table whose rows were lost.

The edit is in a shared upstream file (`server/goose/migrate.go`) wrapped in an `OPENFRAME(migration-race)` sentinel so the next upstream sync re-applies it. This is a **defensive guard**; the durable root-cause fix is restoring the migration Helm hook so migrations finish before the server starts (tracked separately).

## Improvements

- `server/goose/migrate.go`: `GetDBVersion` returns `(0, nil)` for an empty/unseeded version table instead of `panic("unreachable")` — no more crash loop on a fresh DB.
- Self-heals both the migration↔serve startup race and a version table whose rows were lost (pairs with the fork's idempotent migrations).
- Wrapped in `OPENFRAME(migration-race)` and registered in `openframe/scripts/verify.sh` so a future sync can't silently drop it.
- Regression test `TestGetDBVersion_EmptyVersionTableReturnsZeroNotPanic` (`server/goose/migrate_openframe_test.go`, go-sqlmock, no live MySQL).
- Documented in `openframe/docs/migrations.md`.

## Task

<!-- Add the related ticket link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration handling when a version table exists but has no recorded migrations, so upgrades continue from a clean state instead of failing.
  * Updated validation to recognize an additional migration marker during verification.

* **Tests**
  * Added a regression test covering the empty migration table case to prevent future panics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->