### PR TITLE
Annotations for PVC

### DIFF
--- a/charts/fleet/templates/pvc-vulnprocessing.yaml
+++ b/charts/fleet/templates/pvc-vulnprocessing.yaml
@@ -7,6 +7,10 @@ kind: PersistentVolumeClaim
 metadata:
   name: fleet-vulnprocessing
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.vulnProcessing.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app: fleet
     chart: fleet

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -185,6 +185,10 @@ vulnProcessing:
     # existingClaim: ""  # reuse a pre-created PVC instead of the chart-managed one
     storageClassName: ""  # empty = cluster default
     size: 5Gi
+    # Extra annotations for the chart-managed PVC. With WaitForFirstConsumer
+    # storage classes the claim stays Pending until the first cron tick; Argo CD
+    # users may want: argocd.argoproj.io/ignore-healthcheck: "true"
+    annotations: {}
   # <<< OPENFRAME(vuln-persistence)
   resources:
     limits:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Helm deployments can now add custom annotations to the `fleet-vulnprocessing` PersistentVolumeClaim.
  * A new chart setting is available to configure PVC annotations with a default empty value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->