### PR TITLE
fix(vulnerabilities): treat 0-byte cpe.sqlite as absent so failed syncs self-heal

### DIFF
--- a/openframe/docs/fork-file-manifest.md
+++ b/openframe/docs/fork-file-manifest.md
@@ -223,7 +223,7 @@ server/service/openframe/openframe_authorization_manager.go
 server/service/openframe/openframe_token_refresher.go
 ```
 
-### Modified (45)
+### Modified (46)
 
 ```
 .github/pull_request_template.md
@@ -271,4 +271,5 @@ server/service/handler.go
 server/service/labels_util.go
 server/service/orbit_client.go
 server/service/queries.go
+server/vulnerabilities/nvd/cpe.go
 ```

--- a/openframe/docs/helm-chart.md
+++ b/openframe/docs/helm-chart.md
@@ -179,6 +179,19 @@ name) and the sync skips it when its mtime is "today", so after a Fleet upgrade 
 persisted copy can lag by up to a day. Deleting the PVC (the data is a disposable
 cache) forces a full re-sync.
 
+Server-side guard (`server/vulnerabilities/nvd/cpe.go`): when a feed sync fails
+but the scan continues, the CPE translation phase opens the missing
+`cpe.sqlite` with the sqlite driver, which creates an **empty 0-byte file**. On
+an emptyDir that artifact dies with the pod, but on a persisted volume its
+fresh mtime satisfies both freshness gates in `DownloadCPEDBFromGithub` and the
+real download is never retried — vuln processing wedges until the next
+`fleetdm/nvd` release (~24h) while the Job reports Success. The fork adds a
+`stat.Size() == 0 → treat as absent` case ahead of the mtime gate, so the next
+run after a transient failure (rate limit, GitHub outage) re-downloads
+immediately. The write path is temp-file + atomic rename, so replacing the
+empty file is safe. A non-empty corrupt file would still pass, but that cannot
+be produced by this code path — only by disk corruption.
+
 ## Operator quick reference
 
 Tenant-style install (external DB + shared Redis + OpenFrame mode):

--- a/server/vulnerabilities/nvd/cpe.go
+++ b/server/vulnerabilities/nvd/cpe.go
@@ -78,6 +78,14 @@ func DownloadCPEDBFromGithub(vulnPath string, cpeDBURL string) error {
 			// okay
 		case err != nil:
 			return err
+		// >>> OPENFRAME(vuln-persistence): a 0-byte cpe.sqlite must not satisfy the freshness gates — openframe/docs/helm-chart.md
+		case stat.Size() == 0:
+			// Leftover from a failed sync: the CPE translation phase creates an
+			// empty DB when opening a missing file. Treat it as absent so the
+			// download below runs; the temp-file + atomic rename write path
+			// replaces it safely.
+			stat = nil
+		// <<< OPENFRAME(vuln-persistence)
 		case stat.ModTime().Truncate(24 * time.Hour).Equal(time.Now().Truncate(24 * time.Hour)):
 			// Vulnerability assets are published once per day - if the asset in question has a
 			// mod date of 'today', then we can assume that is already up to day so there's nothing

--- a/server/vulnerabilities/nvd/cpe_test.go
+++ b/server/vulnerabilities/nvd/cpe_test.go
@@ -256,6 +256,29 @@ func TestCPETranslations(t *testing.T) {
 	}
 }
 
+// >>> OPENFRAME(vuln-persistence): regression test — 0-byte cpe.sqlite must trigger a re-download — openframe/docs/helm-chart.md
+func TestDownloadCPEDBFromGithubEmptyFile(t *testing.T) {
+	nettest.Run(t)
+
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "cpe.sqlite")
+
+	// A 0-byte cpe.sqlite with a fresh mtime is what a failed sync leaves
+	// behind on a persistent volume: the scan phase opens the missing DB with
+	// the sqlite driver, which creates it empty. It must be treated as absent
+	// ("download"), not as "already downloaded today".
+	require.NoError(t, os.WriteFile(dbPath, nil, 0o644))
+
+	err := DownloadCPEDBFromGithub(tempDir, "")
+	require.NoError(t, err)
+
+	stat, err := os.Stat(dbPath)
+	require.NoError(t, err)
+	require.Greater(t, stat.Size(), int64(0))
+}
+
+// <<< OPENFRAME(vuln-persistence)
+
 func TestSyncCPEDatabase(t *testing.T) {
 	nettest.Run(t)
 


### PR DESCRIPTION
## Description
`DownloadCPEDBFromGithub` decides whether to download purely from `os.Stat` metadata. When a feed sync fails but the scan continues, the CPE translation phase opens the missing `cpe.sqlite` with the sqlite driver, which creates an empty 0-byte file. From then on that file's fresh mtime satisfies both freshness gates ("modified today" and "newer than latest release"), so the real download is never retried — vulnerability processing wedges for up to ~24h (until the next `fleetdm/nvd` release invalidates gate 2) while the CronJob reports Success.

The old `emptyDir` setup masked this: the poisoned file died with the pod. With the persistent feed cache (#61/#64/#66) it survives indefinitely, which is the wedge observed on dev.

Fix: one new `switch` case ahead of the mtime gate — `stat.Size() == 0` → treat the file as absent (`stat = nil`, neutralizing both gates). The downloader writes via temp-file + atomic rename, so the empty file is replaced safely and a partial download can never land in its place. The wedge window collapses from "until the next nvd release" to "until the next successful cron tick".

## Improvements
- `server/vulnerabilities/nvd/cpe.go`: treat a 0-byte `cpe.sqlite` as absent in `DownloadCPEDBFromGithub` (wrapped in `OPENFRAME(vuln-persistence)` sentinels).
- `server/vulnerabilities/nvd/cpe_test.go`: regression test `TestDownloadCPEDBFromGithubEmptyFile` (nettest-gated). Verified both ways: fails on unpatched code, passes with the fix.
- `openframe/docs/helm-chart.md`: documented the server-side guard in the vuln-persistence section.
- `openframe/docs/fork-file-manifest.md`: added `server/vulnerabilities/nvd/cpe.go` to the modified-files inventory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CPE database updates so an empty local database file is treated as missing and re-downloaded correctly.
  * Prevented the app from incorrectly considering a zero-byte database file up to date.
* **Tests**
  * Added regression coverage to verify empty database files trigger a fresh download and are replaced with valid content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->