### PR TITLE
fix(release): also move the latest docker manifest on versioned releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -92,3 +92,8 @@ docker_manifests:
     image_templates:
       - "{{ .Env.REGISTRY }}/{{ .Env.GITHUB_REPOSITORY }}/fleet:{{ .Env.DOCKER_TAG }}-amd64"
       - "{{ .Env.REGISTRY }}/{{ .Env.GITHUB_REPOSITORY }}/fleet:{{ .Env.DOCKER_TAG }}-arm64"
+  - name_template: "{{ .Env.REGISTRY }}/{{ .Env.GITHUB_REPOSITORY }}/fleet:latest"
+    image_templates:
+      - "{{ .Env.REGISTRY }}/{{ .Env.GITHUB_REPOSITORY }}/fleet:{{ .Env.DOCKER_TAG }}-amd64"
+      - "{{ .Env.REGISTRY }}/{{ .Env.GITHUB_REPOSITORY }}/fleet:{{ .Env.DOCKER_TAG }}-arm64"
+    skip_push: "{{ if or (eq .Env.DOCKER_PUSH \"false\") (eq .Env.DOCKER_TAG \"latest\") }}true{{ else }}false{{ end }}"


### PR DESCRIPTION
## Description
Dispatch-triggered releases (`workflow_dispatch` → `DOCKER_TAG=<version>`, see `release.yml:204`) push only the versioned image tags (`0.2.9`, `0.2.9-amd64`, `0.2.9-arm64`). The `latest` manifest is only produced when `DOCKER_TAG` itself is `latest` (push-triggered builds), so the tag froze on 2026-06-24 while versioned releases kept shipping.

Dev environments are built around `latest`: `values-dev.yaml` pins `imageTag: latest` with Keel poll annotations. With `latest` frozen, Keel never sees a digest change and `kubectl rollout restart` faithfully re-pulls the same two-week-old image — dispatch-built images (including the 0.2.9 cpe.sqlite self-heal fix from #68) never reach dev.

Fix: a second `docker_manifests` entry in `.goreleaser.yml` that publishes `fleet:latest` from the same per-arch images built for the versioned tag. It is skipped when `DOCKER_PUSH=false` or when `DOCKER_TAG` is already `latest` (would duplicate the first manifest).

## Improvements
- `.goreleaser.yml`: publish the `latest` multi-arch manifest alongside the versioned one on dispatch releases; no extra builds — it references the already-pushed `-amd64`/`-arm64` images.

## Task
Follow-up to #68 / release 0.2.9 — unblocks dev (Keel + `imageTag: latest`) from receiving dispatch-built images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Docker `latest` manifest so the published image now includes a stable `latest` tag.
  * Improved release behavior to avoid unnecessary duplicate pushes when `latest` is already being used or image pushing is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->