### PR TITLE
ci(release): verify client artifacts instead of silent || true

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,26 +204,6 @@ jobs:
           DOCKER_PUSH: "true"
         run: goreleaser release --clean
 
-      - name: Verify latest tag points at this release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ needs.version.outputs.version }}
-        run: |
-          set -euo pipefail
-          image="${REGISTRY}/${GITHUB_REPOSITORY}/${BINARY_NAME}"
-          ver_digest=$(docker buildx imagetools inspect "${image}:${VERSION}" --format '{{json .Manifest.Digest}}' 2>/dev/null | tr -d '"')
-          latest_digest=$(docker buildx imagetools inspect "${image}:latest" --format '{{json .Manifest.Digest}}' 2>/dev/null | tr -d '"')
-          echo "version (${VERSION}) digest: ${ver_digest:-<none>}"
-          echo "latest digest:            ${latest_digest:-<none>}"
-          if [ -z "$ver_digest" ]; then
-            echo "::error::${image}:${VERSION} was not pushed"
-            exit 1
-          fi
-          if [ "$ver_digest" != "$latest_digest" ]; then
-            echo "::error::${image}:latest did not move to this release (${VERSION}); dev pins latest and would keep serving a stale image"
-            exit 1
-          fi
-
 
   build_helm:
     name: "Build Helm Chart"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,6 +204,26 @@ jobs:
           DOCKER_PUSH: "true"
         run: goreleaser release --clean
 
+      - name: Verify latest tag points at this release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          image="${REGISTRY}/${GITHUB_REPOSITORY}/${BINARY_NAME}"
+          ver_digest=$(docker buildx imagetools inspect "${image}:${VERSION}" --format '{{json .Manifest.Digest}}' 2>/dev/null | tr -d '"')
+          latest_digest=$(docker buildx imagetools inspect "${image}:latest" --format '{{json .Manifest.Digest}}' 2>/dev/null | tr -d '"')
+          echo "version (${VERSION}) digest: ${ver_digest:-<none>}"
+          echo "latest digest:            ${latest_digest:-<none>}"
+          if [ -z "$ver_digest" ]; then
+            echo "::error::${image}:${VERSION} was not pushed"
+            exit 1
+          fi
+          if [ "$ver_digest" != "$latest_digest" ]; then
+            echo "::error::${image}:latest did not move to this release (${VERSION}); dev pins latest and would keep serving a stale image"
+            exit 1
+          fi
+
 
   build_helm:
     name: "Build Helm Chart"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,6 +204,30 @@ jobs:
           DOCKER_PUSH: "true"
         run: goreleaser release --clean
 
+      - name: Verify latest tag was pushed
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          image="${REGISTRY}/${GITHUB_REPOSITORY}/${BINARY_NAME}"
+          latest_digest=$(docker buildx imagetools inspect "${image}:latest" --format '{{json .Manifest.Digest}}' 2>/dev/null | tr -d '"' || true)
+          if [ -z "$latest_digest" ]; then
+            echo "::error::${image}:latest was not pushed by this release"
+            exit 1
+          fi
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            ver_digest=$(docker buildx imagetools inspect "${image}:${VERSION}" --format '{{json .Manifest.Digest}}' 2>/dev/null | tr -d '"' || true)
+            if [ -z "$ver_digest" ]; then
+              echo "::error::${image}:${VERSION} was not pushed"
+              exit 1
+            fi
+            if [ "$ver_digest" != "$latest_digest" ]; then
+              echo "::error::${image}:latest did not move to ${VERSION}; dev pins latest and would keep serving a stale image"
+              exit 1
+            fi
+          fi
+
 
   build_helm:
     name: "Build Helm Chart"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,12 +246,19 @@ jobs:
         continue-on-error: true
 
       - name: Prepare release artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -e
+          set -euo pipefail
           mkdir -p final-artifacts/clients
-          gh release download latest --pattern "*.tar.gz" --pattern "*.zip" --dir final-artifacts/clients || true
 
           # macOS
+          if gh release view latest >/dev/null 2>&1; then
+            gh release download latest --pattern "*.tar.gz" --pattern "*.zip" --dir final-artifacts/clients
+          else
+            echo "No previous 'latest' release yet, skipping carry-forward."
+          fi
+
           if [ -d "release-artifacts/fleet-mac-universal" ]; then
             tar -czf "final-artifacts/clients/fleet-macos-universal.tar.gz" \
               -C "release-artifacts/fleet-mac-universal" fleet
@@ -263,6 +270,20 @@ jobs:
           fi
 
           ls -lh final-artifacts/clients/
+
+          missing=0
+          if [ ! -f final-artifacts/clients/fleet-macos-universal.tar.gz ]; then
+            echo "::error::fleet-macos-universal.tar.gz missing from release artifacts"
+            missing=1
+          fi
+          if [ ! -f final-artifacts/clients/fleet-windows-amd64.zip ]; then
+            echo "::error::fleet-windows-amd64.zip missing from release artifacts"
+            missing=1
+          fi
+          if [ "$missing" -ne 0 ]; then
+            echo "::error::Release would ship incomplete client binaries, failing."
+            exit 1
+          fi
 
       - name: Generate release header
         run: |


### PR DESCRIPTION
release.yml relied on 'gh release download latest ... || true' — any download failure was swallowed. Combined with a conditionally-skipped build_client, a release could ship missing/stale client binaries while the run stayed green. Now: carry-forward runs only when a latest release exists (first-release case still works), download failures are no longer silenced, and both client platforms are verified present before publishing (fail otherwise).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release packaging checks to prevent publishing incomplete client builds.
  * Added safer handling when no previous “latest” release is available, avoiding failed artifact carry-forward steps.
  * Strengthened release automation so failures are detected earlier and surfaced clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->