### PR TITLE
feat(helm): vulnProcessing CronJob annotations passthrough

### DIFF
--- a/charts/fleet/templates/vulnprocessing/cronjob.yaml
+++ b/charts/fleet/templates/vulnprocessing/cronjob.yaml
@@ -9,6 +9,10 @@ metadata:
     release: {{ .Release.Name }}
   name: fleet-vulnprocessing
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.vulnProcessing.annotations }}
+  annotations:
+    {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
 spec:
   # >>> OPENFRAME(vuln-persistence): optional namespace-derived hourly stagger — openframe/docs/helm-chart.md
   {{- if .Values.vulnProcessing.staggerSchedule }}

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -178,6 +178,11 @@ vulnProcessing:
   # When true, `schedule` is ignored and the job runs hourly at a minute derived
   # from the release namespace, so tenants sharing a cluster don't all fire at :00.
   staggerSchedule: false
+  # Extra annotations for the CronJob object. Argo CD users: set
+  # argocd.argoproj.io/ignore-healthcheck: "true" — the built-in CronJob health
+  # check marks it Degraded after a single failed run until the next success,
+  # which otherwise degrades the whole Application (argo-cd issue #24429).
+  annotations: {}
   # Persist FLEET_VULNERABILITIES_DATABASES_PATH (/tmp/vuln) across runs so each
   # run only fetches feed deltas instead of the full ~800MB. Requires dedicated=true.
   persistence:


### PR DESCRIPTION
Adds `vulnProcessing.annotations` passthrough on the fleet-vulnprocessing CronJob.

Context: today three tenants went Degraded after the vuln-persistence disks were deleted directly in GCP. While recovering, the built-in Argo CD CronJob health check surfaced: one failed run marks the CronJob Degraded until the next success (argoproj/argo-cd#24429), which degrades the whole tenant app and fails sync operations. This passthrough lets the tenant chart set `argocd.argoproj.io/ignore-healthcheck: "true"` — consistent with the existing bind-job workaround for #22940.

Consumer change follows in openframe-saas-tenant after this chart is released.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring annotations on the vulnerability processing CronJob.
  * Included guidance for preventing Argo CD from marking the CronJob as degraded after a failed run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->