### PR TITLE
existingSecret instead of secretName

### DIFF
--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -624,7 +624,9 @@ spec:
         {{- if .Values.database.tls.enabled }}
         - name: mysql-tls
           secret:
-            secretName: "{{ .Values.database.secretName }}"
+            # >>> OPENFRAME(helm): the server CA rides in the same externally managed Secret as
+            secretName: "{{ default .Values.database.secretName .Values.database.existingSecret }}"
+            # <<< OPENFRAME(helm)
         {{- end }}
         {{- if or (eq .Values.osquery.logging.statusPlugin "filesystem") (eq .Values.osquery.logging.resultPlugin "filesystem") }}
         - name: osquery-logs

--- a/charts/fleet/templates/job-migration.yaml
+++ b/charts/fleet/templates/job-migration.yaml
@@ -227,7 +227,9 @@ spec:
         {{- if .Values.database.tls.enabled }}
         - name: mysql-tls
           secret:
-            secretName: "{{ .Values.database.secretName }}"
+            # >>> OPENFRAME(helm): the server CA rides in the same externally managed Secret as
+            secretName: "{{ default .Values.database.secretName .Values.database.existingSecret }}"
+            # <<< OPENFRAME(helm)
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/fleet/templates/rbac.yaml
+++ b/charts/fleet/templates/rbac.yaml
@@ -14,7 +14,9 @@ rules:
   resources:
   - secrets
   resourceNames:
-  - {{ .Values.database.secretName }}
+  # >>> OPENFRAME(helm): mirror the mysql-tls volume source — openframe/docs/helm-chart.md
+  - {{ default .Values.database.secretName .Values.database.existingSecret }}
+  # <<< OPENFRAME(helm)
   - {{ .Values.cache.secretName }}
   - {{ .Values.fleet.secretName }}
   - {{ .Values.osquery.secretName }}

--- a/charts/fleet/templates/vulnprocessing/cronjob.yaml
+++ b/charts/fleet/templates/vulnprocessing/cronjob.yaml
@@ -388,7 +388,9 @@ spec:
             {{- if .Values.database.tls.enabled }}
             - name: mysql-tls
               secret:
-                secretName: "{{ .Values.database.secretName }}"
+                # >>> OPENFRAME(helm): the server CA rides in the same externally managed Secret
+                secretName: "{{ default .Values.database.secretName .Values.database.existingSecret }}"
+                # <<< OPENFRAME(helm)
             {{- end }}
             # >>> OPENFRAME(helm): fork-added CA truststore volumes (configmaps/secrets) — openframe/docs/helm-chart.md
             {{- if include "fleet.additionalCAs.enabled" . }}

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -268,7 +268,8 @@ osquery:
 ## Section: database
 # All of the connection settings for MySQL
 database:
-  # Name of the Secret resource containing MySQL password and TLS secrets
+  # Name of the Secret resource containing MySQL password and TLS secrets.
+  # Only used when existingSecret is empty — see existingSecret below.
   secretName: mysql
   # >>> OPENFRAME(helm): fork-externalized DB connection config (ConfigMap/Secret refs) — openframe/docs/helm-chart.md
   # To read connection details from a ConfigMap instead of using static values below:

--- a/openframe/docs/helm-chart.md
+++ b/openframe/docs/helm-chart.md
@@ -92,6 +92,13 @@ just references them.
 | Concern | values.yaml block | `existingConfigMap` / `existingSecret` override | Generated object (when no override) |
 |---------|-------------------|--------------------------------------------------|-------------------------------------|
 | Database | `database.*` | `database.existingConfigMap`, `database.existingSecret` | `fleet-database` ConfigMap (host/port/db/user) + Secret (password) |
+
+`database.existingSecret` covers **both** MySQL secrets: the password (`database.passwordKey`) is read
+from it as an env var, and — when `database.tls.enabled` — the same Secret is mounted at
+`/secrets/mysql`, where `database.tls.caCertKey` names the server CA file. It therefore takes
+precedence over the legacy `database.secretName`, which still applies when `existingSecret` is unset.
+The mount is whole-Secret (no `items:` projection), so every key in it surfaces as a file in the Fleet
+container; keep unrelated material out of that Secret if that matters to you.
 | Cache (Redis) | `cache.*` | `cache.existingConfigMap` | `fleet-cache` ConfigMap (address, key prefix) |
 | Tenant UUID (multi-tenancy) | `fleet.openframe.multiTenancy.*` | `fleet.openframe.multiTenancy.existingConfigMap` | `fleet-openframe-tenant` ConfigMap (`FLEET_OPENFRAME_TENANT_UUID` = `tenantUuid`, empty in shared mode) |
 | Admin setup | `fleet.setup.*` | `fleet.setup.adminPassword.existingSecret` | `fleet-setup` Secret (`FLEET_SETUP_ADMIN_PASSWORD`) |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MySQL TLS Secret handling across deployments, migrations, permissions, and vulnerability processing.
  * Configured externally managed database Secrets are now used when provided, with automatic fallback to the chart-managed Secret.

* **Documentation**
  * Clarified when the database Secret name setting is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->