### PR TITLE
tests: add unit tests for the openframe fork surfaces with no coverage

### DIFF
--- a/client/arch_test.go
+++ b/client/arch_test.go
@@ -16,7 +16,12 @@ func TestClientPackageDoesNotImportServerService(t *testing.T) {
 			m+"/ee/server/service...",
 		).
 		IgnoreDeps(
-			m + "/server/service/externalsvc", // server/fleet has a dependency on Jira and Zendesk.
+			m+"/server/service/externalsvc", // server/fleet has a dependency on Jira and Zendesk.
+			// >>> OPENFRAME(agent-openframe-mode): the orbit client deliberately imports the
+			// openframe auth manager (a leaf package: cron + zerolog only, no service layer) —
+			// openframe/docs/agent-openframe-mode.md
+			m+"/server/service/openframe",
+			// <<< OPENFRAME(agent-openframe-mode)
 		).
 		Check()
 }

--- a/client/orbit_client_openframe_test.go
+++ b/client/orbit_client_openframe_test.go
@@ -1,0 +1,105 @@
+// OPENFRAME(agent-openframe-mode): unit tests for the orbit client's openframe
+// wiring — openframe/docs/agent-openframe-mode.md
+//
+// Guards the two request-path fork edits an upstream refactor of the client
+// would silently drop: the Bearer token injected from the auth manager on
+// every request, and the /tools/agent/fleetmdm-server URL prefix that routes
+// the agent through the OpenFrame gateway.
+package client
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/service/openframe"
+	"github.com/stretchr/testify/require"
+)
+
+// newOpenframeTestClient builds an OrbitClient in openframe mode wired to the
+// given auth manager, mirroring newReenrollTestClient.
+func newOpenframeTestClient(t *testing.T, serverURL string, mgr *openframe.OpenFrameAuthorizationManager) *OrbitClient {
+	t.Helper()
+	bc, err := NewBaseClient(serverURL, true, "", "", nil, fleet.CapabilityMap{}, nil)
+	require.NoError(t, err)
+	_, nodeKeyPath := newNodeKeyFile(t, "a-node-key")
+	return &OrbitClient{
+		BaseClient:      bc,
+		nodeKeyFilePath: nodeKeyPath,
+		enrollSecret:    "secret",
+		hostInfo:        fleet.OrbitHostInfo{HardwareUUID: "uuid-1", Platform: "linux"},
+		openFrameMode:   true,
+		authManager:     mgr,
+	}
+}
+
+func TestOrbitClientOpenframeBearerAuth(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	t.Run("openframe mode injects the manager's token", func(t *testing.T) {
+		oc := newOpenframeTestClient(t, srv.URL, openframe.NewOpenFrameAuthorizationManagerWithToken("tok-1"))
+		require.NoError(t, oc.Ping())
+		require.Equal(t, "Bearer tok-1", gotAuth)
+	})
+
+	t.Run("a rotated token is used on the next request", func(t *testing.T) {
+		mgr := openframe.NewOpenFrameAuthorizationManagerWithToken("tok-1")
+		oc := newOpenframeTestClient(t, srv.URL, mgr)
+		require.NoError(t, oc.Ping())
+		mgr.UpdateToken("tok-2")
+		require.NoError(t, oc.Ping())
+		require.Equal(t, "Bearer tok-2", gotAuth)
+	})
+
+	t.Run("empty token sends no Authorization header", func(t *testing.T) {
+		gotAuth = "sentinel"
+		oc := newOpenframeTestClient(t, srv.URL, openframe.NewOpenFrameAuthorizationManager())
+		require.NoError(t, oc.Ping())
+		require.Empty(t, gotAuth)
+	})
+
+	t.Run("non-openframe mode sends no Authorization header", func(t *testing.T) {
+		gotAuth = "sentinel"
+		_, nodeKeyPath := newNodeKeyFile(t, "a-node-key")
+		oc := newReenrollTestClient(t, srv.URL, nodeKeyPath)
+		require.NoError(t, oc.Ping())
+		require.Empty(t, gotAuth)
+	})
+}
+
+func TestNewOrbitClientOpenframeURLPrefix(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	hostInfo := fleet.OrbitHostInfo{HardwareUUID: "uuid-1", Platform: "linux"}
+
+	t.Run("openframe mode routes through the tools-agent prefix", func(t *testing.T) {
+		oc, err := NewOrbitClient(
+			t.TempDir(), srv.URL, "", true, "secret", nil, hostInfo, nil, nil, "",
+			true, openframe.NewOpenFrameAuthorizationManagerWithToken("tok"),
+		)
+		require.NoError(t, err)
+		require.NoError(t, oc.Ping())
+		require.Equal(t, "/tools/agent/fleetmdm-server/api/fleet/orbit/ping", gotPath)
+	})
+
+	t.Run("non-openframe mode uses the plain path", func(t *testing.T) {
+		oc, err := NewOrbitClient(
+			t.TempDir(), srv.URL, "", true, "secret", nil, hostInfo, nil, nil, "",
+			false, nil,
+		)
+		require.NoError(t, err)
+		require.NoError(t, oc.Ping())
+		require.Equal(t, "/api/fleet/orbit/ping", gotPath)
+	})
+}

--- a/cmd/fleet/cron_openframe_test.go
+++ b/cmd/fleet/cron_openframe_test.go
@@ -1,0 +1,86 @@
+// OPENFRAME(query-results-ttl): unit test for the query_results TTL cleanup
+// cron — openframe/docs/query-results-ttl-cleanup.md
+//
+// This was the only piece of the query-results-ttl slug with no test at all:
+// the schedule construction and the cutoff math (now - TTL) that decides which
+// rows die. mock.Store stands in for the locker/stats store, so no MySQL.
+package main
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/config"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewQueryResultsTTLCleanupSchedule(t *testing.T) {
+	const ttl = 24 * time.Hour
+
+	ds := new(mock.Store)
+	ds.LockFunc = func(ctx context.Context, name, owner string, expiration time.Duration) (bool, error) {
+		return true, nil
+	}
+	ds.UnlockFunc = func(ctx context.Context, name, owner string) error { return nil }
+	// A completed run one hour ago makes the schedule due on its first tick.
+	ds.GetLatestCronStatsFunc = func(ctx context.Context, name string) ([]fleet.CronStats, error) {
+		return []fleet.CronStats{{
+			ID:        1,
+			StatsType: fleet.CronStatsTypeScheduled,
+			Name:      name,
+			Status:    fleet.CronStatsStatusCompleted,
+			CreatedAt: time.Now().Add(-time.Hour),
+			UpdatedAt: time.Now().Add(-time.Hour),
+		}}, nil
+	}
+	ds.InsertCronStatsFunc = func(ctx context.Context, statsType fleet.CronStatsType, name, instance string, status fleet.CronStatsStatus) (int, error) {
+		return 1, nil
+	}
+	ds.UpdateCronStatsFunc = func(ctx context.Context, id int, status fleet.CronStatsStatus, cronErrors *fleet.CronScheduleErrors) error {
+		return nil
+	}
+
+	cutoffCh := make(chan time.Time, 1)
+	ds.CleanupExpiredQueryResultsFunc = func(ctx context.Context, expiredBefore time.Time) (int64, error) {
+		select {
+		case cutoffCh <- expiredBefore:
+		default:
+		}
+		return 5, nil
+	}
+
+	cfg := config.FleetConfig{}
+	cfg.Server.QueryResultsTTL = ttl
+	// The schedule floors sub-second intervals to 1s; use 1s explicitly so the
+	// test's timing expectations match what actually runs.
+	cfg.Server.QueryResultsCleanupInterval = time.Second
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	s, err := newQueryResultsTTLCleanupSchedule(ctx, "test_instance", ds, &cfg, slog.New(slog.DiscardHandler))
+	require.NoError(t, err)
+	require.Equal(t, string(fleet.CronQueryResultsTTLCleanup), s.Name())
+
+	s.Start()
+
+	select {
+	case cutoff := <-cutoffCh:
+		// The job must delete rows older than now - TTL; allow generous slack
+		// for scheduling delay.
+		require.WithinDuration(t, time.Now().Add(-ttl), cutoff, time.Minute)
+	case <-time.After(10 * time.Second):
+		t.Fatal("the TTL cleanup job never ran")
+	}
+
+	cancel()
+	select {
+	case <-s.Done():
+	case <-time.After(10 * time.Second):
+		t.Fatal("schedule did not stop")
+	}
+}

--- a/server/config/config_openframe_test.go
+++ b/server/config/config_openframe_test.go
@@ -1,0 +1,55 @@
+// OPENFRAME(redis-key-prefix, query-results-ttl): unit tests for the
+// fork-added config flags — openframe/docs/redis-key-prefix.md,
+// openframe/docs/query-results-ttl-cleanup.md
+//
+// Both flags are registered inside large upstream flag blocks; a merge that
+// re-generates that block can drop a registration with no compile error,
+// leaving the tenant prefix or the TTL silently at their zero values in every
+// deployment. These tests pin the defaults and the env-var plumbing.
+package config
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/pkg/testutils"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func loadTestConfig(t *testing.T, env map[string]string) FleetConfig {
+	t.Helper()
+	// viper also reads the ambient environment; start from a clean one so a
+	// developer's local FLEET_* vars can't skew the assertions.
+	testutils.SaveEnv(t)
+	os.Clearenv()
+	for k, v := range env {
+		t.Setenv(k, v)
+	}
+
+	cmd := &cobra.Command{}
+	cmd.PersistentFlags().StringP("config", "c", "", "Path to a configuration file")
+	man := NewManager(cmd)
+	return man.LoadConfig()
+}
+
+func TestOpenframeConfigDefaults(t *testing.T) {
+	cfg := loadTestConfig(t, nil)
+
+	require.Empty(t, cfg.Redis.KeyPrefix, "key prefix must default to off (single-tenant Redis)")
+	require.Equal(t, 60*24*time.Hour, cfg.Server.QueryResultsTTL)
+	require.Equal(t, 1*time.Hour, cfg.Server.QueryResultsCleanupInterval)
+}
+
+func TestOpenframeConfigEnvOverrides(t *testing.T) {
+	cfg := loadTestConfig(t, map[string]string{
+		"FLEET_REDIS_KEY_PREFIX":                      "tenant-a",
+		"FLEET_SERVER_QUERY_RESULTS_TTL":              "24h",
+		"FLEET_SERVER_QUERY_RESULTS_CLEANUP_INTERVAL": "30m",
+	})
+
+	require.Equal(t, "tenant-a", cfg.Redis.KeyPrefix)
+	require.Equal(t, 24*time.Hour, cfg.Server.QueryResultsTTL)
+	require.Equal(t, 30*time.Minute, cfg.Server.QueryResultsCleanupInterval)
+}

--- a/server/datastore/mysql/migrations/openframe/migration_test.go
+++ b/server/datastore/mysql/migrations/openframe/migration_test.go
@@ -1,0 +1,121 @@
+// OPENFRAME(host-assignments, mysql-multitenancy): unit tests for the
+// openframe migration pipeline's registration and idempotency helpers —
+// openframe/docs/migrations.md
+//
+// The deep MySQL-backed idempotency tests live in
+// server/datastore/mysql/migrations_openframe_test.go; these cover what runs
+// without Docker: that every migration file's init() actually registered
+// (an upstream sync dropping one is a silent data-loss bug — the table never
+// gets created on fresh installs) and the information_schema probe helpers.
+package openframe
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllOpenframeMigrationsRegistered(t *testing.T) {
+	want := []int64{
+		20260301000001, // AddPolicyHostsJoinTable
+		20260301000002, // AddQueryHostsJoinTable
+		20260620000001, // ScopeLabelUniqueNameToTeam
+		20260626000001, // ScopeHostIdentityUniqueToTeam
+		20260629000001, // AddTeamsOpenframeTenantUUID
+		20260722000001, // AddTeamIdToCdcTables
+	}
+
+	var got []int64
+	for _, m := range MigrationClient.Migrations {
+		got = append(got, m.Version)
+		require.NotNil(t, m.UpFn, "migration %d has no Up function", m.Version)
+	}
+	require.ElementsMatch(t, want, got,
+		"a migration file exists whose init() did not register, or the expected list is stale — update both together")
+}
+
+func TestMigrationClientUsesOwnVersionTable(t *testing.T) {
+	// The openframe pipeline must never share goose state with Fleet's own
+	// migrations: same table would mean colliding version numbers.
+	require.Equal(t, "migration_status_openframe", MigrationClient.TableName)
+}
+
+func newMockTx(t *testing.T) (*sql.Tx, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+	mock.ExpectBegin()
+	tx, err := db.Begin()
+	require.NoError(t, err)
+	return tx, mock
+}
+
+func TestIndexExists(t *testing.T) {
+	cases := []struct {
+		name  string
+		count int
+		want  bool
+	}{
+		{"present", 1, true},
+		{"absent", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tx, mock := newMockTx(t)
+			mock.ExpectQuery("information_schema.STATISTICS").
+				WithArgs("hosts", "idx_test").
+				WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(tc.count))
+
+			got, err := indexExists(tx, "hosts", "idx_test")
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+
+	t.Run("query error propagates", func(t *testing.T) {
+		tx, mock := newMockTx(t)
+		mock.ExpectQuery("information_schema.STATISTICS").
+			WillReturnError(errors.New("boom"))
+
+		_, err := indexExists(tx, "hosts", "idx_test")
+		require.Error(t, err)
+	})
+}
+
+func TestColumnExists(t *testing.T) {
+	cases := []struct {
+		name  string
+		count int
+		want  bool
+	}{
+		{"present", 1, true},
+		{"absent", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tx, mock := newMockTx(t)
+			mock.ExpectQuery("information_schema.COLUMNS").
+				WithArgs("teams", "openframe_tenant_uuid").
+				WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(tc.count))
+
+			got, err := columnExists(tx, "teams", "openframe_tenant_uuid")
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+
+	t.Run("query error propagates", func(t *testing.T) {
+		tx, mock := newMockTx(t)
+		mock.ExpectQuery("information_schema.COLUMNS").
+			WillReturnError(errors.New("boom"))
+
+		_, err := columnExists(tx, "teams", "openframe_tenant_uuid")
+		require.Error(t, err)
+	})
+}

--- a/server/datastore/mysql/openframe_foreign_team_test.go
+++ b/server/datastore/mysql/openframe_foreign_team_test.go
@@ -1,0 +1,31 @@
+// OPENFRAME(mysql-multitenancy): unit test for the explicit-team rejection
+// helper — openframe/docs/mysql-multitenancy-feature.md
+//
+// openframeForeignTeam backs every "caller passed an explicit fleet_id for
+// another tenant" fence; it is pure context logic, so it runs without
+// MYSQL_TEST and catches a sync that breaks the pin plumbing.
+package mysql
+
+import (
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenframeForeignTeam(t *testing.T) {
+	ctx := t.Context()
+
+	// Unpinned process: no tenant scope, so no team is foreign (upstream
+	// behavior must stay unchanged). This assumes no earlier test in this
+	// package pinned the process via fleet.SetOpenframeTeamID or the
+	// FLEET_OPENFRAME_* env vars — the pin and the env decision are cached
+	// process-globals.
+	require.False(t, openframeForeignTeam(ctx, 1))
+	require.False(t, openframeForeignTeam(ctx, 0))
+
+	pinned := fleet.NewOpenframeTeamContext(ctx, 7)
+	require.False(t, openframeForeignTeam(pinned, 7), "own team is never foreign")
+	require.True(t, openframeForeignTeam(pinned, 8), "another tenant's team must be foreign")
+	require.True(t, openframeForeignTeam(pinned, 0))
+}

--- a/server/datastore/redis/keyprefix_conn_test.go
+++ b/server/datastore/redis/keyprefix_conn_test.go
@@ -1,0 +1,255 @@
+// OPENFRAME(redis-key-prefix): unit tests for the prefixedConn wrapper plumbing
+// and the prefix rules not covered by keyprefix_test.go —
+// openframe/docs/redis-key-prefix.md
+//
+// These guard the paths where a regression is silent: a Do/Send that stops
+// routing through prefixArgs, a PUBSUB introspection that leaks other tenants'
+// channels, or a Bind that registers unprefixed keys with redisc.
+package redis
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	redigo "github.com/gomodule/redigo/redis"
+)
+
+// recordingConn captures the command and args the wrapper forwards to the
+// inner conn. It also implements ConnWithTimeout, Bind, and ReadOnly so the
+// wrapper's optional-interface forwarding is testable.
+type recordingConn struct {
+	cmds     []string
+	args     [][]interface{}
+	bound    []string
+	readOnly bool
+}
+
+func (c *recordingConn) Close() error { return nil }
+func (c *recordingConn) Err() error   { return nil }
+func (c *recordingConn) Do(cmd string, args ...interface{}) (interface{}, error) {
+	c.cmds = append(c.cmds, cmd)
+	c.args = append(c.args, args)
+	return nil, nil
+}
+func (c *recordingConn) Send(cmd string, args ...interface{}) error {
+	c.cmds = append(c.cmds, cmd)
+	c.args = append(c.args, args)
+	return nil
+}
+func (c *recordingConn) Flush() error                  { return nil }
+func (c *recordingConn) Receive() (interface{}, error) { return nil, nil }
+func (c *recordingConn) DoWithTimeout(_ time.Duration, cmd string, args ...interface{}) (interface{}, error) {
+	return c.Do(cmd, args...)
+}
+func (c *recordingConn) ReceiveWithTimeout(time.Duration) (interface{}, error) { return nil, nil }
+func (c *recordingConn) Bind(keys ...string) error {
+	c.bound = append(c.bound, keys...)
+	return nil
+}
+func (c *recordingConn) ReadOnly() error {
+	c.readOnly = true
+	return nil
+}
+
+func (c *recordingConn) lastArgs(t *testing.T) []interface{} {
+	t.Helper()
+	if len(c.args) == 0 {
+		t.Fatal("inner conn received no command")
+	}
+	return c.args[len(c.args)-1]
+}
+
+func TestPrefixedConnDoPrefixesKeys(t *testing.T) {
+	rc := &recordingConn{}
+	pc := newPrefixedConn(rc, "t:")
+
+	if _, err := pc.Do("SET", "k", "v"); err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	if want := []interface{}{"t:k", "v"}; !reflect.DeepEqual(rc.lastArgs(t), want) {
+		t.Errorf("Do forwarded %v, want %v", rc.lastArgs(t), want)
+	}
+}
+
+func TestPrefixedConnSendPrefixesKeys(t *testing.T) {
+	rc := &recordingConn{}
+	pc := newPrefixedConn(rc, "t:")
+
+	if err := pc.Send("DEL", "a", "b"); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if want := []interface{}{"t:a", "t:b"}; !reflect.DeepEqual(rc.lastArgs(t), want) {
+		t.Errorf("Send forwarded %v, want %v", rc.lastArgs(t), want)
+	}
+}
+
+func TestPrefixedConnDoWithTimeoutPrefixesKeys(t *testing.T) {
+	rc := &recordingConn{}
+	pc := newPrefixedConn(rc, "t:").(*prefixedConn)
+
+	if _, err := pc.DoWithTimeout(time.Second, "GET", "k"); err != nil {
+		t.Fatalf("DoWithTimeout: %v", err)
+	}
+	if want := []interface{}{"t:k"}; !reflect.DeepEqual(rc.lastArgs(t), want) {
+		t.Errorf("DoWithTimeout forwarded %v, want %v", rc.lastArgs(t), want)
+	}
+}
+
+func TestPrefixedConnBind(t *testing.T) {
+	rc := &recordingConn{}
+	pc := newPrefixedConn(rc, "t:").(*prefixedConn)
+
+	if err := pc.Bind("k1", "k2"); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	if want := []string{"t:k1", "t:k2"}; !reflect.DeepEqual(rc.bound, want) {
+		t.Errorf("Bind forwarded %v, want %v", rc.bound, want)
+	}
+}
+
+func TestPrefixedConnBindInnerWithoutBind(t *testing.T) {
+	var fc redigo.Conn = fakeConn{} // fakeConn has no Bind
+	pc := newPrefixedConn(fc, "t:").(*prefixedConn)
+	if err := pc.Bind("k"); err == nil {
+		t.Error("Bind on an inner conn without Bind must error, not panic or no-op")
+	}
+}
+
+func TestPrefixedConnReadOnly(t *testing.T) {
+	rc := &recordingConn{}
+	pc := newPrefixedConn(rc, "t:").(*prefixedConn)
+
+	if err := pc.ReadOnly(); err != nil {
+		t.Fatalf("ReadOnly: %v", err)
+	}
+	if !rc.readOnly {
+		t.Error("ReadOnly was not forwarded to the inner conn")
+	}
+
+	var fc redigo.Conn = fakeConn{}
+	pcPlain := newPrefixedConn(fc, "t:").(*prefixedConn)
+	if err := pcPlain.ReadOnly(); err == nil {
+		t.Error("ReadOnly on an inner conn without ReadOnly must error")
+	}
+}
+
+// TestPrefixArgs_MoreRules covers the rules and commands the main table in
+// keyprefix_test.go does not: PUBSUB introspection, WATCH, store-variant
+// multi-key commands, SORT without STORE, FCALL, and numKeys-as-string EVAL.
+func TestPrefixArgs_MoreRules(t *testing.T) {
+	const p = "t:"
+
+	cases := []struct {
+		name string
+		cmd  string
+		args []interface{}
+		want []interface{}
+	}{
+		// pubsubArgs: only the channel-taking subcommands get prefixed
+		{"PUBSUB CHANNELS", "PUBSUB", []interface{}{"CHANNELS", "ch*"}, []interface{}{"CHANNELS", "t:ch*"}},
+		{"PUBSUB NUMSUB two channels", "PUBSUB", []interface{}{"NUMSUB", "c1", "c2"}, []interface{}{"NUMSUB", "t:c1", "t:c2"}},
+		{"PUBSUB SHARDCHANNELS", "PUBSUB", []interface{}{"SHARDCHANNELS", "ch*"}, []interface{}{"SHARDCHANNELS", "t:ch*"}},
+		{"PUBSUB SHARDNUMSUB", "PUBSUB", []interface{}{"SHARDNUMSUB", "c1"}, []interface{}{"SHARDNUMSUB", "t:c1"}},
+		{"PUBSUB NUMPAT has no channels", "PUBSUB", []interface{}{"NUMPAT"}, []interface{}{"NUMPAT"}},
+		{"PUBSUB with no subcommand", "PUBSUB", nil, []interface{}{}},
+
+		// transactions: WATCH keys are prefixed, UNWATCH/MULTI/EXEC are not
+		{"WATCH", "WATCH", []interface{}{"k1", "k2"}, []interface{}{"t:k1", "t:k2"}},
+
+		// store variants where every arg is a key
+		{"ZUNIONSTORE", "ZUNIONSTORE", []interface{}{"dst", "s1", "s2"}, []interface{}{"t:dst", "t:s1", "t:s2"}},
+		{"PFMERGE", "PFMERGE", []interface{}{"dst", "s1"}, []interface{}{"t:dst", "t:s1"}},
+
+		// twoKeys variants
+		{"LMOVE keeps directions", "LMOVE", []interface{}{"src", "dst", "LEFT", "RIGHT"}, []interface{}{"t:src", "t:dst", "LEFT", "RIGHT"}},
+		{"ZRANGESTORE keeps range", "ZRANGESTORE", []interface{}{"dst", "src", 0, -1}, []interface{}{"t:dst", "t:src", 0, -1}},
+		{"BRPOPLPUSH keeps timeout", "BRPOPLPUSH", []interface{}{"src", "dst", 5}, []interface{}{"t:src", "t:dst", 5}},
+
+		// blocking pops
+		{"BZPOPMIN", "BZPOPMIN", []interface{}{"z1", "z2", 0}, []interface{}{"t:z1", "t:z2", 0}},
+		{"BLPOP single key", "BLPOP", []interface{}{"k", 1}, []interface{}{"t:k", 1}},
+
+		// sort without STORE: only the source key
+		{"SORT plain", "SORT", []interface{}{"mylist", "LIMIT", 0, 10}, []interface{}{"t:mylist", "LIMIT", 0, 10}},
+
+		// scripting: numKeys arrives as a string over the wire too
+		{"EVAL numKeys as string", "EVAL", []interface{}{"script", "2", "k1", "k2", "argv"}, []interface{}{"script", "2", "t:k1", "t:k2", "argv"}},
+		{"FCALL", "FCALL", []interface{}{"fn", 1, "k", "argv"}, []interface{}{"fn", 1, "t:k", "argv"}},
+		{"EVAL with numKeys beyond args stays in bounds", "EVAL", []interface{}{"script", 5, "k1"}, []interface{}{"script", 5, "t:k1"}},
+		{"EVAL single arg untouched", "EVAL", []interface{}{"script"}, []interface{}{"script"}},
+
+		// object: non-inspecting subcommand untouched
+		{"OBJECT HELP", "OBJECT", []interface{}{"HELP"}, []interface{}{"HELP"}},
+
+		// shard pub/sub channels
+		{"SSUBSCRIBE", "SSUBSCRIBE", []interface{}{"c1"}, []interface{}{"t:c1"}},
+
+		// empty args on a default-rule command must not panic
+		{"GET with no args", "GET", nil, []interface{}{}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := prefixArgs(tc.cmd, tc.args, p)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("prefixArgs(%q, %v) = %v, want %v", tc.cmd, tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPrefixArgs_DoesNotMutateInput(t *testing.T) {
+	args := []interface{}{"k", "v"}
+	_ = prefixArgs("SET", args, "t:")
+	if args[0] != "k" {
+		t.Errorf("prefixArgs mutated the caller's args slice: %v", args)
+	}
+}
+
+func TestPrefixOne_OutOfRange(t *testing.T) {
+	args := []interface{}{"k"}
+	prefixOne(args, -1, "t:") // must not panic
+	prefixOne(args, 1, "t:")  // must not panic
+	if args[0] != "k" {
+		t.Errorf("out-of-range prefixOne mutated args: %v", args)
+	}
+}
+
+func TestToInt(t *testing.T) {
+	cases := []struct {
+		in   interface{}
+		want int
+	}{
+		{2, 2},
+		{int64(3), 3},
+		{int32(4), 4},
+		{uint(5), 5},
+		{uint64(6), 6},
+		{"7", 7},
+		{"not a number", 0},
+		{nil, 0},
+		{3.9, 0}, // unsupported type: fail closed to 0 keys, not a partial prefix
+	}
+	for _, tc := range cases {
+		if got := toInt(tc.in); got != tc.want {
+			t.Errorf("toInt(%v) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestToString(t *testing.T) {
+	cases := []struct {
+		in   interface{}
+		want string
+	}{
+		{"s", "s"},
+		{[]byte("b"), "b"},
+		{42, "42"},
+	}
+	for _, tc := range cases {
+		if got := toString(tc.in); got != tc.want {
+			t.Errorf("toString(%v) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/server/fleet/hosts_openframe_test.go
+++ b/server/fleet/hosts_openframe_test.go
@@ -1,0 +1,30 @@
+// OPENFRAME(osquery-host-id): unit test for the API exposure of
+// osquery_host_id — openframe/docs/api-expose-osquery-host-id.md
+//
+// Upstream tags this field json:"-"; the fork exposes it because OpenFrame
+// correlates devices by their osquery host id. A merge that takes upstream's
+// struct tag would drop the field from every host API response with no
+// compile error — this test turns that into a red build.
+package fleet
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHostJSONExposesOsqueryHostID(t *testing.T) {
+	h := Host{OsqueryHostID: new("host-uuid-1")}
+
+	b, err := json.Marshal(h)
+	require.NoError(t, err)
+	require.Contains(t, string(b), `"osquery_host_id":"host-uuid-1"`)
+
+	var back struct {
+		OsqueryHostID *string `json:"osquery_host_id"`
+	}
+	require.NoError(t, json.Unmarshal(b, &back))
+	require.NotNil(t, back.OsqueryHostID)
+	require.Equal(t, "host-uuid-1", *back.OsqueryHostID)
+}

--- a/server/service/host_assignments_openframe_test.go
+++ b/server/service/host_assignments_openframe_test.go
@@ -1,0 +1,296 @@
+// OPENFRAME(host-assignments): unit tests for the fork-only host-assignment
+// service methods — openframe/docs/architecture-host-assignments.md
+//
+// The 8 svc methods (add/remove/replace/list × policy/query hosts) previously
+// had only a manual curl script; this pins down the openframe-mode gate, the
+// authorization order, host-existence validation (incl. de-duplication), and
+// delegation to the datastore, so an upstream sync cannot silently drop any of
+// them. mock.Store only — no external deps.
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// newHostAssignmentTestSvc builds a service around a mock store pre-wired with
+// a global policy 1 and a global query 1, plus hosts 1..3. The returned
+// contexts carry the test license plus an admin/observer viewer.
+func newHostAssignmentTestSvc(t *testing.T) (svc fleet.Service, ds *mock.Store, adminCtx, observerCtx context.Context) {
+	t.Helper()
+	ds = new(mock.Store)
+	ds.PolicyFunc = func(ctx context.Context, id uint) (*fleet.Policy, error) {
+		return &fleet.Policy{PolicyData: fleet.PolicyData{ID: id}}, nil
+	}
+	ds.QueryFunc = func(ctx context.Context, id uint) (*fleet.Query, error) {
+		return &fleet.Query{ID: id}, nil
+	}
+	ds.ListHostsLiteByIDsFunc = func(ctx context.Context, ids []uint) ([]*fleet.Host, error) {
+		var hosts []*fleet.Host
+		for _, id := range ids {
+			if id <= 3 {
+				hosts = append(hosts, &fleet.Host{ID: id})
+			}
+		}
+		return hosts, nil
+	}
+	svc, baseCtx := newTestService(t, ds, nil, nil)
+	adminCtx = viewer.NewContext(baseCtx, viewer.Viewer{User: &fleet.User{ID: 1, GlobalRole: new(fleet.RoleAdmin)}})
+	observerCtx = viewer.NewContext(baseCtx, viewer.Viewer{User: &fleet.User{ID: 2, GlobalRole: new(fleet.RoleObserver)}})
+	return svc, ds, adminCtx, observerCtx
+}
+
+// TestOpenframeHostAssignmentsRequireOpenframeMode: every method must reject
+// with BadRequest when FLEET_OPENFRAME_MODE is unset, before touching authz or
+// the datastore.
+func TestOpenframeHostAssignmentsRequireOpenframeMode(t *testing.T) {
+	t.Setenv("FLEET_OPENFRAME_MODE", "") // hermetic baseline: don't depend on the ambient shell env
+	svc, ds, ctx, _ := newHostAssignmentTestSvc(t)
+
+	calls := map[string]func() error{
+		"AddPolicyHosts":     func() error { _, err := svc.AddPolicyHosts(ctx, 1, []uint{1}); return err },
+		"RemovePolicyHosts":  func() error { _, err := svc.RemovePolicyHosts(ctx, 1, []uint{1}); return err },
+		"ReplacePolicyHosts": func() error { return svc.ReplacePolicyHosts(ctx, 1, []uint{1}) },
+		"ListPolicyHosts":    func() error { _, _, err := svc.ListPolicyHosts(ctx, 1, fleet.ListOptions{}); return err },
+		"AddQueryHosts":      func() error { _, err := svc.AddQueryHosts(ctx, 1, []uint{1}); return err },
+		"RemoveQueryHosts":   func() error { _, err := svc.RemoveQueryHosts(ctx, 1, []uint{1}); return err },
+		"ReplaceQueryHosts":  func() error { return svc.ReplaceQueryHosts(ctx, 1, []uint{1}) },
+		"ListQueryHosts":     func() error { _, _, err := svc.ListQueryHosts(ctx, 1, fleet.ListOptions{}); return err },
+	}
+	for name, call := range calls {
+		t.Run(name, func(t *testing.T) {
+			err := call()
+			require.Error(t, err)
+			var br *fleet.BadRequestError
+			require.ErrorAs(t, err, &br)
+		})
+	}
+	require.False(t, ds.PolicyFuncInvoked, "the mode gate must fire before any datastore access")
+	require.False(t, ds.QueryFuncInvoked, "the mode gate must fire before any datastore access")
+}
+
+func TestOpenframePolicyHostAssignments(t *testing.T) {
+	t.Setenv("FLEET_OPENFRAME_MODE", "1")
+
+	t.Run("add delegates to the datastore", func(t *testing.T) {
+		svc, ds, adminCtx, _ := newHostAssignmentTestSvc(t)
+		var gotPolicyID uint
+		var gotHostIDs []uint
+		ds.AddPolicyHostsFunc = func(ctx context.Context, policyID uint, hostIDs []uint) (uint, error) {
+			gotPolicyID, gotHostIDs = policyID, hostIDs
+			return uint(len(hostIDs)), nil
+		}
+		n, err := svc.AddPolicyHosts(adminCtx, 1, []uint{1, 2})
+		require.NoError(t, err)
+		require.Equal(t, uint(2), n)
+		require.True(t, ds.AddPolicyHostsFuncInvoked)
+		require.Equal(t, uint(1), gotPolicyID)
+		require.Equal(t, []uint{1, 2}, gotHostIDs)
+	})
+
+	t.Run("add rejects nonexistent hosts", func(t *testing.T) {
+		svc, ds, adminCtx, _ := newHostAssignmentTestSvc(t)
+		ds.AddPolicyHostsFunc = func(ctx context.Context, policyID uint, hostIDs []uint) (uint, error) {
+			return uint(len(hostIDs)), nil
+		}
+		_, err := svc.AddPolicyHosts(adminCtx, 1, []uint{1, 99})
+		require.Error(t, err, "host 99 does not exist")
+		require.False(t, ds.AddPolicyHostsFuncInvoked, "validation must run before the write")
+	})
+
+	t.Run("add deduplicates host ids before validating", func(t *testing.T) {
+		svc, ds, adminCtx, _ := newHostAssignmentTestSvc(t)
+		var validatedIDs []uint
+		ds.ListHostsLiteByIDsFunc = func(ctx context.Context, ids []uint) ([]*fleet.Host, error) {
+			validatedIDs = ids
+			hosts := make([]*fleet.Host, len(ids))
+			for i, id := range ids {
+				hosts[i] = &fleet.Host{ID: id}
+			}
+			return hosts, nil
+		}
+		ds.AddPolicyHostsFunc = func(ctx context.Context, policyID uint, hostIDs []uint) (uint, error) {
+			return uint(len(hostIDs)), nil
+		}
+		_, err := svc.AddPolicyHosts(adminCtx, 1, []uint{2, 2, 3, 2})
+		require.NoError(t, err)
+		require.Equal(t, []uint{2, 3}, validatedIDs,
+			"duplicate ids must collapse or the existence count check would spuriously fail")
+	})
+
+	t.Run("observer cannot write assignments", func(t *testing.T) {
+		svc, ds, _, observerCtx := newHostAssignmentTestSvc(t)
+		_, err := svc.AddPolicyHosts(observerCtx, 1, []uint{1})
+		require.Error(t, err)
+		_, err = svc.RemovePolicyHosts(observerCtx, 1, []uint{1})
+		require.Error(t, err)
+		require.Error(t, svc.ReplacePolicyHosts(observerCtx, 1, []uint{1}))
+		require.False(t, ds.AddPolicyHostsFuncInvoked)
+		require.False(t, ds.RemovePolicyHostsFuncInvoked)
+		require.False(t, ds.ReplacePolicyHostsFuncInvoked)
+	})
+
+	t.Run("observer can list assignments", func(t *testing.T) {
+		svc, ds, _, observerCtx := newHostAssignmentTestSvc(t)
+		ds.ListPolicyHostsFunc = func(ctx context.Context, policyID uint, opts fleet.ListOptions) ([]fleet.HostIdent, *fleet.PaginationMetadata, error) {
+			return []fleet.HostIdent{{HostID: 1}}, nil, nil
+		}
+		hosts, _, err := svc.ListPolicyHosts(observerCtx, 1, fleet.ListOptions{})
+		require.NoError(t, err)
+		require.Len(t, hosts, 1)
+	})
+
+	t.Run("remove delegates without host validation", func(t *testing.T) {
+		// Removing an already-deleted host must keep working, so Remove does
+		// not require the hosts to still exist.
+		svc, ds, adminCtx, _ := newHostAssignmentTestSvc(t)
+		ds.RemovePolicyHostsFunc = func(ctx context.Context, policyID uint, hostIDs []uint) (uint, error) {
+			return uint(len(hostIDs)), nil
+		}
+		n, err := svc.RemovePolicyHosts(adminCtx, 1, []uint{99})
+		require.NoError(t, err)
+		require.Equal(t, uint(1), n)
+		require.False(t, ds.ListHostsLiteByIDsFuncInvoked)
+	})
+
+	t.Run("replace validates then delegates", func(t *testing.T) {
+		svc, ds, adminCtx, _ := newHostAssignmentTestSvc(t)
+		var gotHostIDs []uint
+		ds.ReplacePolicyHostsFunc = func(ctx context.Context, policyID uint, hostIDs []uint) error {
+			gotHostIDs = hostIDs
+			return nil
+		}
+		require.NoError(t, svc.ReplacePolicyHosts(adminCtx, 1, []uint{1, 3}))
+		require.Equal(t, []uint{1, 3}, gotHostIDs)
+
+		require.Error(t, svc.ReplacePolicyHosts(adminCtx, 1, []uint{99}))
+	})
+
+	t.Run("missing policy surfaces the datastore error", func(t *testing.T) {
+		svc, ds, adminCtx, _ := newHostAssignmentTestSvc(t)
+		ds.PolicyFunc = func(ctx context.Context, id uint) (*fleet.Policy, error) {
+			return nil, errors.New("policy not found")
+		}
+		_, err := svc.AddPolicyHosts(adminCtx, 42, []uint{1})
+		require.Error(t, err)
+		require.False(t, ds.AddPolicyHostsFuncInvoked)
+	})
+}
+
+func TestOpenframeQueryHostAssignments(t *testing.T) {
+	t.Setenv("FLEET_OPENFRAME_MODE", "1")
+
+	t.Run("add validates then delegates", func(t *testing.T) {
+		svc, ds, adminCtx, _ := newHostAssignmentTestSvc(t)
+		var gotQueryID uint
+		var gotHostIDs []uint
+		ds.AddQueryHostsFunc = func(ctx context.Context, queryID uint, hostIDs []uint) (uint, error) {
+			gotQueryID, gotHostIDs = queryID, hostIDs
+			return uint(len(hostIDs)), nil
+		}
+		n, err := svc.AddQueryHosts(adminCtx, 1, []uint{2, 3})
+		require.NoError(t, err)
+		require.Equal(t, uint(2), n)
+		require.Equal(t, uint(1), gotQueryID)
+		require.Equal(t, []uint{2, 3}, gotHostIDs)
+
+		_, err = svc.AddQueryHosts(adminCtx, 1, []uint{99})
+		require.Error(t, err, "host 99 does not exist")
+	})
+
+	t.Run("observer cannot write assignments", func(t *testing.T) {
+		svc, ds, _, observerCtx := newHostAssignmentTestSvc(t)
+		_, err := svc.AddQueryHosts(observerCtx, 1, []uint{1})
+		require.Error(t, err)
+		_, err = svc.RemoveQueryHosts(observerCtx, 1, []uint{1})
+		require.Error(t, err)
+		require.Error(t, svc.ReplaceQueryHosts(observerCtx, 1, []uint{1}))
+		require.False(t, ds.AddQueryHostsFuncInvoked)
+		require.False(t, ds.RemoveQueryHostsFuncInvoked)
+		require.False(t, ds.ReplaceQueryHostsFuncInvoked)
+	})
+
+	t.Run("remove and replace delegate", func(t *testing.T) {
+		svc, ds, adminCtx, _ := newHostAssignmentTestSvc(t)
+		ds.RemoveQueryHostsFunc = func(ctx context.Context, queryID uint, hostIDs []uint) (uint, error) {
+			return uint(len(hostIDs)), nil
+		}
+		ds.ReplaceQueryHostsFunc = func(ctx context.Context, queryID uint, hostIDs []uint) error {
+			return nil
+		}
+		n, err := svc.RemoveQueryHosts(adminCtx, 1, []uint{1, 2})
+		require.NoError(t, err)
+		require.Equal(t, uint(2), n)
+		require.NoError(t, svc.ReplaceQueryHosts(adminCtx, 1, []uint{1}))
+		require.True(t, ds.RemoveQueryHostsFuncInvoked)
+		require.True(t, ds.ReplaceQueryHostsFuncInvoked)
+	})
+
+	t.Run("list delegates and returns metadata", func(t *testing.T) {
+		svc, ds, adminCtx, _ := newHostAssignmentTestSvc(t)
+		meta := &fleet.PaginationMetadata{HasNextResults: true}
+		ds.ListQueryHostsFunc = func(ctx context.Context, queryID uint, opts fleet.ListOptions) ([]fleet.HostIdent, *fleet.PaginationMetadata, error) {
+			return []fleet.HostIdent{{HostID: 1}, {HostID: 2}}, meta, nil
+		}
+		hosts, gotMeta, err := svc.ListQueryHosts(adminCtx, 1, fleet.ListOptions{})
+		require.NoError(t, err)
+		require.Len(t, hosts, 2)
+		require.Equal(t, meta, gotMeta)
+	})
+
+	t.Run("missing query surfaces the datastore error", func(t *testing.T) {
+		svc, ds, adminCtx, _ := newHostAssignmentTestSvc(t)
+		ds.QueryFunc = func(ctx context.Context, id uint) (*fleet.Query, error) {
+			return nil, errors.New("query not found")
+		}
+		_, _, err := svc.ListQueryHosts(adminCtx, 42, fleet.ListOptions{})
+		require.Error(t, err)
+		require.False(t, ds.ListQueryHostsFuncInvoked)
+	})
+}
+
+// TestVerifyHostsToAssociate covers the shared host-existence validator used
+// by the add/replace paths.
+func TestVerifyHostsToAssociate(t *testing.T) {
+	t.Run("empty list skips the datastore", func(t *testing.T) {
+		ds := new(mock.Store)
+		require.NoError(t, verifyHostsToAssociate(t.Context(), ds, nil))
+		require.False(t, ds.ListHostsLiteByIDsFuncInvoked)
+	})
+
+	t.Run("all hosts exist", func(t *testing.T) {
+		ds := new(mock.Store)
+		ds.ListHostsLiteByIDsFunc = func(ctx context.Context, ids []uint) ([]*fleet.Host, error) {
+			hosts := make([]*fleet.Host, len(ids))
+			for i, id := range ids {
+				hosts[i] = &fleet.Host{ID: id}
+			}
+			return hosts, nil
+		}
+		require.NoError(t, verifyHostsToAssociate(t.Context(), ds, []uint{1, 2}))
+	})
+
+	t.Run("a missing host fails", func(t *testing.T) {
+		ds := new(mock.Store)
+		ds.ListHostsLiteByIDsFunc = func(ctx context.Context, ids []uint) ([]*fleet.Host, error) {
+			return nil, nil
+		}
+		require.Error(t, verifyHostsToAssociate(t.Context(), ds, []uint{1}))
+	})
+
+	t.Run("datastore error is propagated", func(t *testing.T) {
+		ds := new(mock.Store)
+		ds.ListHostsLiteByIDsFunc = func(ctx context.Context, ids []uint) ([]*fleet.Host, error) {
+			return nil, errors.New("boom")
+		}
+		err := verifyHostsToAssociate(t.Context(), ds, []uint{1})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "boom")
+	})
+}

--- a/server/service/openframe/openframe_test.go
+++ b/server/service/openframe/openframe_test.go
@@ -1,0 +1,260 @@
+// OPENFRAME(agent-openframe-mode): unit tests for the agent token-auth pipeline —
+// openframe/docs/agent-openframe-mode.md
+//
+// The encryption service, token extractor, authorization manager, and refresher
+// carry the agent's gateway credentials; a silent regression here (e.g. an
+// upstream refactor changing the payload format or dropping the refresh skip
+// logic) would break every enrolled agent's authentication. Pure logic + a temp
+// dir — no external deps.
+package openframe
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// aes256Key is a 32-byte key matching the AES-256 deployments use.
+const aes256Key = "0123456789abcdef0123456789abcdef"
+
+// encryptForTest produces base64(nonce || AES-GCM ciphertext) — the exact
+// payload format Decrypt expects on disk.
+func encryptForTest(t *testing.T, key string, plaintext []byte) string {
+	t.Helper()
+	block, err := aes.NewCipher([]byte(key))
+	require.NoError(t, err)
+	gcm, err := cipher.NewGCM(block)
+	require.NoError(t, err)
+	nonce := make([]byte, gcm.NonceSize())
+	_, err = rand.Read(nonce)
+	require.NoError(t, err)
+	return base64.StdEncoding.EncodeToString(gcm.Seal(nonce, nonce, plaintext, nil))
+}
+
+func TestDecryptRoundTrip(t *testing.T) {
+	// All three AES key sizes must work: the key comes from deployment config,
+	// not from code, so none of the sizes is "the" supported one.
+	keys := map[string]string{
+		"AES-128": "0123456789abcdef",
+		"AES-192": "0123456789abcdef01234567",
+		"AES-256": aes256Key,
+	}
+	for name, key := range keys {
+		t.Run(name, func(t *testing.T) {
+			es := NewOpenframeEncryptionService(key)
+			payload := encryptForTest(t, key, []byte("the-token"))
+			got, err := es.Decrypt(payload)
+			require.NoError(t, err)
+			require.Equal(t, []byte("the-token"), got)
+		})
+	}
+}
+
+func TestDecryptEmptyPlaintext(t *testing.T) {
+	es := NewOpenframeEncryptionService(aes256Key)
+	got, err := es.Decrypt(encryptForTest(t, aes256Key, []byte{}))
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+func TestDecryptInvalidBase64(t *testing.T) {
+	es := NewOpenframeEncryptionService(aes256Key)
+	_, err := es.Decrypt("%%% not base64 %%%")
+	require.Error(t, err)
+}
+
+func TestDecryptBadKeyLength(t *testing.T) {
+	es := NewOpenframeEncryptionService("short-key")
+	_, err := es.Decrypt(base64.StdEncoding.EncodeToString([]byte("whatever")))
+	require.Error(t, err)
+}
+
+func TestDecryptCiphertextTooShort(t *testing.T) {
+	// Fewer bytes than the 12-byte GCM nonce must error, not panic on slicing.
+	es := NewOpenframeEncryptionService(aes256Key)
+	_, err := es.Decrypt(base64.StdEncoding.EncodeToString([]byte("tiny")))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ciphertext too short")
+}
+
+func TestDecryptWrongKey(t *testing.T) {
+	payload := encryptForTest(t, aes256Key, []byte("the-token"))
+	es := NewOpenframeEncryptionService("fedcba9876543210fedcba9876543210")
+	_, err := es.Decrypt(payload)
+	require.Error(t, err, "GCM must reject a payload sealed with a different key")
+}
+
+func TestDecryptTamperedCiphertext(t *testing.T) {
+	payload := encryptForTest(t, aes256Key, []byte("the-token"))
+	raw, err := base64.StdEncoding.DecodeString(payload)
+	require.NoError(t, err)
+	raw[len(raw)-1] ^= 0xff
+	es := NewOpenframeEncryptionService(aes256Key)
+	_, err = es.Decrypt(base64.StdEncoding.EncodeToString(raw))
+	require.Error(t, err, "GCM must reject a tampered ciphertext")
+}
+
+func TestDecryptErrorCountResetsOnSuccess(t *testing.T) {
+	es := NewOpenframeEncryptionService(aes256Key)
+	_, err := es.Decrypt("%%% not base64 %%%")
+	require.Error(t, err)
+	require.Equal(t, 1, es.decryptErrCount)
+
+	_, err = es.Decrypt(encryptForTest(t, aes256Key, []byte("ok")))
+	require.NoError(t, err)
+	require.Equal(t, 0, es.decryptErrCount, "a successful decrypt must reset the rate-limit counter")
+}
+
+func writeTokenFile(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "token")
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return path
+}
+
+func TestExtractToken(t *testing.T) {
+	es := NewOpenframeEncryptionService(aes256Key)
+
+	t.Run("reads and decrypts the token file", func(t *testing.T) {
+		path := writeTokenFile(t, encryptForTest(t, aes256Key, []byte("agent-token")))
+		te := NewOpenframeTokenExtractor(es, path)
+		token, err := te.ExtractToken()
+		require.NoError(t, err)
+		require.Equal(t, "agent-token", token)
+	})
+
+	t.Run("missing file errors and counts", func(t *testing.T) {
+		te := NewOpenframeTokenExtractor(es, filepath.Join(t.TempDir(), "does-not-exist"))
+		_, err := te.ExtractToken()
+		require.Error(t, err)
+		require.Equal(t, 1, te.readErrCount)
+	})
+
+	t.Run("read error count resets on success", func(t *testing.T) {
+		path := writeTokenFile(t, encryptForTest(t, aes256Key, []byte("agent-token")))
+		te := NewOpenframeTokenExtractor(es, path)
+		te.readErrCount = 3
+		_, err := te.ExtractToken()
+		require.NoError(t, err)
+		require.Equal(t, 0, te.readErrCount)
+	})
+
+	t.Run("undecryptable file contents error", func(t *testing.T) {
+		path := writeTokenFile(t, "not-even-base64 %%%")
+		te := NewOpenframeTokenExtractor(es, path)
+		_, err := te.ExtractToken()
+		require.Error(t, err)
+	})
+}
+
+func TestAuthorizationManager(t *testing.T) {
+	t.Run("starts empty", func(t *testing.T) {
+		m := NewOpenFrameAuthorizationManager()
+		require.Equal(t, "", m.GetToken())
+	})
+
+	t.Run("with-token constructor seeds the token", func(t *testing.T) {
+		m := NewOpenFrameAuthorizationManagerWithToken("seed")
+		require.Equal(t, "seed", m.GetToken())
+	})
+
+	t.Run("update replaces the token", func(t *testing.T) {
+		m := NewOpenFrameAuthorizationManagerWithToken("old")
+		m.UpdateToken("new")
+		require.Equal(t, "new", m.GetToken())
+	})
+
+	// The manager is read on every request while the cron refresher writes;
+	// run with -race to catch a dropped mutex.
+	t.Run("concurrent readers and writers", func(t *testing.T) {
+		m := NewOpenFrameAuthorizationManager()
+		var wg sync.WaitGroup
+		for i := 0; i < 8; i++ {
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				for j := 0; j < 100; j++ {
+					m.UpdateToken("tok")
+				}
+			}()
+			go func() {
+				defer wg.Done()
+				for j := 0; j < 100; j++ {
+					_ = m.GetToken()
+				}
+			}()
+		}
+		wg.Wait()
+		require.Equal(t, "tok", m.GetToken())
+	})
+}
+
+func TestRefreshToken(t *testing.T) {
+	es := NewOpenframeEncryptionService(aes256Key)
+
+	newRefresher := func(t *testing.T, tokenPath string) (*OpenframeTokenRefresher, *OpenFrameAuthorizationManager) {
+		t.Helper()
+		mgr := NewOpenFrameAuthorizationManager()
+		te := NewOpenframeTokenExtractor(es, tokenPath)
+		return NewOpenframeTokenRefresher(te, mgr), mgr
+	}
+
+	t.Run("stores a freshly extracted token", func(t *testing.T) {
+		path := writeTokenFile(t, encryptForTest(t, aes256Key, []byte("tok-1")))
+		tr, mgr := newRefresher(t, path)
+		tr.refreshToken()
+		require.Equal(t, "tok-1", mgr.GetToken())
+	})
+
+	t.Run("picks up a rotated token", func(t *testing.T) {
+		path := writeTokenFile(t, encryptForTest(t, aes256Key, []byte("tok-1")))
+		tr, mgr := newRefresher(t, path)
+		tr.refreshToken()
+		require.NoError(t, os.WriteFile(path, []byte(encryptForTest(t, aes256Key, []byte("tok-2"))), 0o600))
+		tr.refreshToken()
+		require.Equal(t, "tok-2", mgr.GetToken())
+	})
+
+	t.Run("empty extracted token is not stored", func(t *testing.T) {
+		path := writeTokenFile(t, encryptForTest(t, aes256Key, []byte{}))
+		tr, mgr := newRefresher(t, path)
+		mgr.UpdateToken("existing")
+		tr.refreshToken()
+		require.Equal(t, "existing", mgr.GetToken(), "an empty token must never clobber a working one")
+	})
+
+	t.Run("extract failure keeps the current token", func(t *testing.T) {
+		tr, mgr := newRefresher(t, filepath.Join(t.TempDir(), "gone"))
+		mgr.UpdateToken("existing")
+		tr.refreshToken()
+		require.Equal(t, "existing", mgr.GetToken())
+		require.Equal(t, 1, tr.extractErrCount)
+	})
+
+	t.Run("error count resets on the next successful extract", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "token")
+		mgr := NewOpenFrameAuthorizationManager()
+		tr := NewOpenframeTokenRefresher(NewOpenframeTokenExtractor(es, path), mgr)
+		tr.refreshToken() // file missing
+		require.Equal(t, 1, tr.extractErrCount)
+		require.NoError(t, os.WriteFile(path, []byte(encryptForTest(t, aes256Key, []byte("tok"))), 0o600))
+		tr.refreshToken()
+		require.Equal(t, 0, tr.extractErrCount)
+		require.Equal(t, "tok", mgr.GetToken())
+	})
+}
+
+func TestRefresherStartStop(t *testing.T) {
+	path := writeTokenFile(t, encryptForTest(t, aes256Key, []byte("tok")))
+	mgr := NewOpenFrameAuthorizationManager()
+	tr := NewOpenframeTokenRefresher(NewOpenframeTokenExtractor(NewOpenframeEncryptionService(aes256Key), path), mgr)
+	require.NoError(t, tr.Start())
+	tr.Stop() // must not hang waiting for jobs
+}

--- a/server/service/osquery_utils/queries_openframe_sql_test.go
+++ b/server/service/osquery_utils/queries_openframe_sql_test.go
@@ -1,0 +1,35 @@
+// OPENFRAME(waf-inventory-shape): guards the query side of the DN hex-encoding
+// — openframe/docs/agent-inventory-waf-shape.md
+//
+// The ingest side (decodeCertificateDNColumns) is covered in queries_test.go;
+// this pins the SQL itself. An upstream sync that takes upstream's certificate
+// detail queries would drop the hex() wrapping with no git conflict, and every
+// inventory write would start tripping the edge WAF's SQLi rules again.
+package osquery_utils
+
+import (
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/config"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenframeCertificateQueriesHexEncodeDN(t *testing.T) {
+	queries := GetDetailQueries(t.Context(), config.FleetConfig{}, nil, &fleet.Features{}, Integrations{}, nil)
+
+	for _, name := range []string{"certificates_darwin", "certificates_windows"} {
+		q, ok := queries[name]
+		require.True(t, ok, "detail query %s is missing", name)
+
+		for _, col := range []string{
+			"hex(common_name) AS common_name_hex",
+			"hex(subject) AS subject_hex",
+			"hex(issuer) AS issuer_hex",
+		} {
+			require.Contains(t, q.Query, col, "%s must hex-encode its DN columns for the WAF", name)
+		}
+		// The raw columns must not leak through alongside the hex ones.
+		require.NotRegexp(t, `(?m)^\s*subject\s*,`, q.Query, "%s selects a raw DN column", name)
+	}
+}


### PR DESCRIPTION
Guard the fork-only code against regressions during upstream syncs:

- server/service/openframe: the whole agent token-auth pipeline had zero tests — AES-GCM decrypt (all key sizes, short/tampered/wrong-key payloads, error-count reset), token file extraction, the RW-mutex authorization manager (race-checked), and the refresh skip logic (empty/unchanged token, extract failures).
- redis key-prefix: prefixedConn Do/Send/DoWithTimeout/Bind/ReadOnly forwarding, the PUBSUB introspection rule, WATCH/store-variant/LMOVE/ ZRANGESTORE/blocking-pop/FCALL table cases, input-slice immutability, and toInt/toString/prefixOne edge cases.
- host-assignments service layer: the 8 add/remove/replace/list svc methods previously had only a manual curl script — now pin the openframe-mode gate, authz ordering (observer write rejection), host existence validation with de-duplication, and datastore delegation, plus direct tests for verifyHostsToAssociate.
- mysql: openframeForeignTeam pin/foreign/unpinned decision (pure ctx logic, runs without MYSQL_TEST).