### PR TITLE
fix(multitenancy): CU-86ah5x16c drop agent options from the tenant app config

### DIFF
--- a/server/datastore/mysql/app_configs.go
+++ b/server/datastore/mysql/app_configs.go
@@ -60,11 +60,12 @@ func appConfigDB(ctx context.Context, q sqlx.QueryerContext) (*fleet.AppConfig, 
 	}
 	if err == sql.ErrNoRows {
 		// >>> OPENFRAME(mysql-multitenancy): a pinned tenant may have no app_config_json row yet
-		// (team created, config never saved) — return defaults so software inventory / host users
-		// aren't silently off. Unpinned keeps the upstream bare-config behavior.
+		// (team created before config seeding shipped, row manually deleted) — serve the same
+		// config EnsureOpenframeTeamID seeds, so software inventory / host users aren't silently
+		// off and no agent options override orbit's endpoints. Unpinned keeps the upstream
+		// bare-config behavior.
 		if _, ok := fleet.OpenframeTeamID(ctx); ok {
-			info.ApplyDefaultsForNewInstalls()
-			return info, nil
+			return OpenframeDefaultAppConfig(), nil
 		}
 		// <<< OPENFRAME(mysql-multitenancy)
 		return &fleet.AppConfig{}, nil

--- a/server/datastore/mysql/openframe.go
+++ b/server/datastore/mysql/openframe.go
@@ -181,8 +181,7 @@ func (ds *Datastore) EnsureOpenframeTeamID(ctx context.Context, tenantUUID strin
 			`INSERT INTO enroll_secrets (secret, team_id) VALUES (?, ?)`, secret, id); err != nil {
 			return ctxerr.Wrap(ctx, err, "seeding openframe team enroll secret")
 		}
-		appConfig := &fleet.AppConfig{}
-		appConfig.ApplyDefaultsForNewInstalls()
+		appConfig := OpenframeDefaultAppConfig()
 		configBytes, err := json.Marshal(appConfig)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "marshaling openframe team app config")
@@ -202,6 +201,21 @@ func (ds *Datastore) EnsureOpenframeTeamID(ctx context.Context, tenantUUID strin
 		return 0, ctxerr.Wrap(ctx, err, "creating openframe team for tenant uuid")
 	}
 	return id, nil
+}
+
+// OpenframeDefaultAppConfig is the config a tenant is born with in shared mode — the equivalent
+// of what POST /setup persists on a dedicated Fleet, since shared mode runs setup once for the
+// whole database and never per tenant.
+//
+// Upstream's new-install defaults are taken as-is except for agent options, which are dropped.
+// In openframe mode the agent reaches Fleet through the gateway's /tools/agent/fleetmdm-server
+// prefix and orbit passes every osquery endpoint on the command line accordingly; osquery lets
+// served config options override those flags.
+func OpenframeDefaultAppConfig() *fleet.AppConfig {
+	appConfig := &fleet.AppConfig{}
+	appConfig.ApplyDefaultsForNewInstalls()
+	appConfig.AgentOptions = nil
+	return appConfig
 }
 
 // openframeMigrationLockName is the cluster-wide MySQL named lock serializing schema

--- a/server/datastore/mysql/teams_openframe_test.go
+++ b/server/datastore/mysql/teams_openframe_test.go
@@ -102,27 +102,10 @@ func TestOpenframeEnsureTeamID(t *testing.T) {
 	require.True(t, appConfigA.Features.EnableSoftwareInventory)
 	require.True(t, appConfigA.Features.EnableHostUsers)
 
-	// Re-resolving must not replace the tenant's config either: a manual change survives.
-	appConfigA.Features.EnableSoftwareInventory = false
-	require.NoError(t, ds.SaveAppConfig(ctxA, appConfigA))
-	_, err = ds.EnsureOpenframeTeamID(ctx, uuidA)
-	require.NoError(t, err)
-	appConfigAAgain, err := ds.AppConfig(ctxA)
-	require.NoError(t, err)
-	require.False(t, appConfigAAgain.Features.EnableSoftwareInventory)
-
-	// A newly created team is seeded with a persisted per-tenant app config row carrying
-	// new-install defaults, so the pinned config read serves software inventory enabled instead
-	// of falling back to ApplyDefaults (which leaves it — and vulnerabilities — off).
-	var configRows int
-	require.NoError(t, ds.writer(ctx).GetContext(ctx, &configRows,
-		"SELECT COUNT(*) FROM app_config_json WHERE id = ?", idA))
-	require.Equal(t, 1, configRows)
-
-	appConfigA, err := ds.AppConfig(ctxA)
-	require.NoError(t, err)
-	require.True(t, appConfigA.Features.EnableSoftwareInventory)
-	require.True(t, appConfigA.Features.EnableHostUsers)
+	// No agent options are served: in openframe mode orbit passes every osquery endpoint on the
+	// command line (gateway-prefixed), and a served logger_tls_endpoint would override those
+	// flags with an unprefixed path, silently dropping every result and status log.
+	require.Nil(t, appConfigA.AgentOptions)
 
 	// Re-resolving must not replace the tenant's config either: a manual change survives.
 	appConfigA.Features.EnableSoftwareInventory = false
@@ -141,6 +124,7 @@ func TestOpenframeEnsureTeamID(t *testing.T) {
 	appConfigB, err := ds.AppConfig(ctxB)
 	require.NoError(t, err)
 	require.True(t, appConfigB.Features.EnableSoftwareInventory)
+	require.Nil(t, appConfigB.AgentOptions)
 
 	// A team with operator-applied (or backfilled) secrets keeps them: replace A's secret set,
 	// re-resolve, and confirm the applied set is untouched.


### PR DESCRIPTION
[CU-86ah5x16c](https://app.clickup.com/t/9013925967/86ah5x16c)

The per-tenant app config seeded by `EnsureOpenframeTeamID` (#133) carried upstream's default agent options, including `logger_tls_endpoint: /api/osquery/log`. Served config options override osquery's command-line flags, so in openframe mode that replaced orbit's gateway-prefixed `/tools/agent/fleetmdm-server/api/v1/osquery/log` with an unprefixed path — every scheduled query result and status log was silently dropped. Per-tenant Fleets served no agent options, which is why delivery worked there.

`OpenframeDefaultAppConfig()` now applies the new-install defaults minus agent options, and both the seed and the pinned read fallback use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)